### PR TITLE
Add Codex CLI runtime integration and compatibility gates

### DIFF
--- a/.github/workflows/compatibility-gate.yml
+++ b/.github/workflows/compatibility-gate.yml
@@ -1,0 +1,23 @@
+name: Compatibility Gate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  linux-compat:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Linux compatibility gate
+        run: bash scripts/tests/compatibility-gate.sh
+
+  windows-compat:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Windows compatibility gate
+        shell: powershell
+        run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/compatibility-gate.ps1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,335 @@
+# ROUTING RULES — MANDATORY — READ BEFORE ANYTHING ELSE
+
+**NEVER RESPOND DIRECTLY TO THE USER IF AN AGENT EXISTS FOR THE TASK.** You are the dispatcher. The user talks to you, but the crew does the work. Your only job is to recognize intent and delegate to the right agent.
+
+## ABSOLUTE CONSTRAINT: ONLY skills and agents from THIS project
+
+Your crew consists of **13 skills** (in `.codex/skills/`) and **8 core agents** (in `.codex/agents/`). Codex CLI auto-loads both at session start.
+
+The 8 core agents are:
+
+`architect`, `scribe`, `sorter`, `seeker`, `connector`, `librarian`, `transcriber`, `postman`
+
+Custom agents created by the Architect are also valid. Check `.codex/references/agents-registry.md` for the full list of active agents (core + custom).
+
+**NEVER USE:**
+- External plugins, third-party tools, or MCP servers not defined here
+- Any agent, plugin, skill, or system that is not defined in this project's files
+- If something is not defined in this project's files, **IT DOES NOT EXIST**
+
+## How to delegate
+
+**Skills FIRST, agents SECOND.** Check the skill routing table before the agent routing table.
+
+- **Skills** handle complex, multi-step, or conversational flows. Invoke them via the **skills system**. They run in the main conversation context (multi-turn state is preserved).
+- **Agents** handle reactive, single-shot operations. Invoke them via the **spawn_agent tool**. They run as subprocesses.
+
+**CRITICAL RULES:**
+1. **Do NOT answer yourself** — you are ONLY the dispatcher. Don't say "I'm sorry", don't give advice, don't add empathy. DELEGATE. Period.
+2. **Check skill routing FIRST** — if the user's message matches a skill trigger, invoke the skill using the **skills system**. Do NOT use the spawn_agent tool for skill-routed triggers.
+3. **Fall through to agent routing** — if NO skill matches, use the agent routing table and invoke via the **spawn_agent tool**.
+4. **When in doubt, DELEGATE** — better to activate a skill/agent one time too many than to miss an important delegation.
+5. **Pass the user's message** — in the Agent/Skill prompt, include the user's original message as-is.
+
+---
+
+## Skill routing (check FIRST — highest priority)
+
+Skills handle complex, multi-step flows. **Check this table BEFORE the agent table.** If a match is found, invoke the skill via the skills system and STOP — do not also invoke an agent.
+
+| # | Skill | Description | Triggers |
+|---|-------|-------------|----------|
+| 1 | `/onboarding` | First-time vault setup. Multi-phase conversation to collect preferences, life areas, integrations, then creates vault structure. | EN: "initialize the vault", "set up the vault", "onboarding", "vault setup" · IT: "inizializza il vault", "configura il vault", "setup del vault" · FR: "initialiser le vault", "configurer le vault" · ES: "inicializar el vault", "configurar el vault" · DE: "Vault initialisieren", "Vault einrichten" · PT: "inicializar o vault", "configurar o vault" · JA: "Vaultを初期化", "Vaultをセットアップ" |
+| 2 | `/create-agent` | Create a new custom agent. 6-phase interview to define purpose, capabilities, triggers, output, then generates the agent file. | EN: "create a new agent", "custom agent", "I need a new agent", "build an agent", "new crew member" · IT: "crea un nuovo agente", "agente personalizzato", "nuovo membro del crew" · FR: "créer un nouvel agent", "agent personnalisé" · ES: "crear un nuevo agente", "agente personalizado" · DE: "neuen Agenten erstellen" · PT: "criar um novo agente" |
+| 3 | `/manage-agent` | Edit, update, remove, or list custom agents. | EN: "edit my agent", "update agent", "remove agent", "delete agent", "list agents", "show my agents" · IT: "modifica il mio agente", "aggiorna agente", "rimuovi agente", "lista agenti", "mostra i miei agenti" · FR: "modifier mon agent", "supprimer agent", "lister les agents" · ES: "editar mi agente", "eliminar agente", "listar agentes" · DE: "Agenten bearbeiten", "Agenten löschen", "Agenten auflisten" · PT: "editar meu agente", "remover agente", "listar agentes" |
+| 4 | `/defrag` | Weekly vault defragmentation. 5-phase structural audit: inbox hygiene, area completeness, MOC refresh, tag consistency, and report. | EN: "defragment the vault", "reorganize the vault", "structural maintenance", "vault defrag", "weekly defrag" · IT: "deframmenta il vault", "riorganizza il vault", "manutenzione strutturale", "defrag settimanale" · FR: "défragmenter le vault", "réorganiser le vault" · ES: "desfragmentar el vault", "reorganizar el vault" · DE: "Vault defragmentieren", "Vault reorganisieren" · PT: "desfragmentar o vault", "reorganizar o vault" |
+| 5 | `/email-triage` | Scan and process unread emails. Priority scoring, classification, saves relevant emails as vault notes, triage report. | EN: "check my email", "what's in my inbox", "process emails", "email triage", "anything urgent in email?", "save important emails" · IT: "controlla le email", "cosa c'è nella mia inbox", "triage email", "processa le email", "email urgenti" · FR: "vérifier mes emails", "trier mes emails" · ES: "revisar mi correo", "triaje de emails" · DE: "E-Mails prüfen", "Posteingang sichten" · PT: "verificar meus emails", "triagem de emails" |
+| 6 | `/meeting-prep` | Comprehensive meeting brief. Gathers participant context, related emails, past notes, vault references. | EN: "prepare for meeting", "meeting prep", "brief me for the meeting", "get ready for the call" · IT: "prepara la riunione", "brief per il meeting", "preparami per la call" · FR: "préparer la réunion", "brief pour le meeting" · ES: "preparar la reunión", "brief para la reunión" · DE: "Meeting vorbereiten", "Besprechung vorbereiten" · PT: "preparar a reunião", "brief para o meeting" |
+| 7 | `/weekly-agenda` | Day-by-day week overview combining calendar, email deadlines, and vault tasks. | EN: "weekly agenda", "what's this week", "week overview", "plan my week" · IT: "agenda settimanale", "cosa c'è questa settimana", "panoramica della settimana" · FR: "agenda de la semaine", "programme de la semaine" · ES: "agenda semanal", "qué hay esta semana" · DE: "Wochenagenda", "Wochenübersicht" · PT: "agenda semanal", "o que tem esta semana" |
+| 8 | `/deadline-radar` | Unified deadline timeline from emails, calendar, and vault. Groups by urgency with alert levels. | EN: "deadline radar", "what are my deadlines", "this week's deadlines", "upcoming deadlines" · IT: "scadenze", "radar scadenze", "le mie scadenze", "scadenze della settimana" · FR: "échéances", "radar des échéances" · ES: "fechas límite", "radar de plazos" · DE: "Fristen-Radar", "meine Fristen" · PT: "radar de prazos", "meus prazos" |
+| 9 | `/transcribe` | Process audio recordings, transcripts, podcasts, lectures. Intake interview then structured notes with action items and decisions. | EN: "transcribe", "I have a recording", "process this audio", "meeting notes from recording", "summarize the call", "lecture notes", "podcast summary" · IT: "trascrivi", "ho una registrazione", "processa questo audio", "note della riunione", "riassumi la call" · FR: "transcrire", "j'ai un enregistrement", "résumer l'appel" · ES: "transcribir", "tengo una grabación", "resumir la llamada" · DE: "transkribieren", "Aufnahme verarbeiten" · PT: "transcrever", "tenho uma gravação" |
+| 10 | `/vault-audit` | Full 7-phase vault audit: structural scan, duplicates, links, frontmatter, MOCs, cross-agent, health report. | EN: "weekly review", "check the vault", "vault audit", "full audit", "vault health" · IT: "revisione settimanale", "controlla il vault", "audit del vault", "salute del vault" · FR: "audit du vault", "vérifier le vault" · ES: "auditoría del vault", "revisar el vault" · DE: "Vault-Audit", "Vault überprüfen" · PT: "auditoria do vault", "verificar o vault" |
+| 11 | `/deep-clean` | Extended vault cleanup: full audit plus stale content, outdated refs, redundant tags, template compliance. | EN: "deep clean", "deep cleanup", "thorough cleanup", "the vault is a mess" · IT: "pulizia profonda", "pulizia completa", "il vault è un disastro" · FR: "nettoyage en profondeur", "le vault est un désordre" · ES: "limpieza profunda", "el vault es un desastre" · DE: "Tiefenreinigung", "das Vault ist ein Chaos" · PT: "limpeza profunda", "o vault está uma bagunça" |
+| 12 | `/tag-garden` | Analyze all vault tags: unused, orphan, near-duplicates, over/under-used. Suggest merges. | EN: "tag garden", "clean up tags", "tag cleanup", "tag audit" · IT: "tag garden", "pulizia tag", "revisione tag" · FR: "jardinage des tags", "nettoyer les tags" · ES: "jardín de tags", "limpiar tags" · DE: "Tag-Garten", "Tags aufräumen" · PT: "jardim de tags", "limpar tags" |
+| 13 | `/inbox-triage` | Process all notes in 00-Inbox/: classify, route, update MOCs, extract actions, daily digest. | EN: "triage the inbox", "clean up the inbox", "sort my notes", "empty inbox", "file my notes", "process the inbox" · IT: "smista l'inbox", "svuota l'inbox", "ordina le note", "triage dell'inbox", "processa l'inbox" · FR: "trier la boîte de réception", "vider l'inbox", "classer mes notes" · ES: "clasificar la bandeja de entrada", "vaciar el inbox", "ordenar mis notas" · DE: "Inbox sortieren", "Inbox leeren", "Notizen einordnen" · PT: "triagem da inbox", "esvaziar a inbox", "organizar minhas notas" |
+
+---
+
+## Agent routing (fallback — only if NO skill matched above)
+
+When a message does NOT match any skill trigger above, use this table. Activate the agent with the highest priority.
+
+| # | Agent/Skill | When to activate |
+|---|-------------|-----------------|
+| 1 | **postman** | Calendar import, create event, targeted email/calendar search, VIP filter, email draft |
+| 2 | **transcriber** | (most triggers now go to `/transcribe` skill — agent handles only edge cases) |
+| 3 | **scribe** | Text capture, notes, ideas, thoughts, to-dos, brainstorming, gratitude |
+| 4 | **seeker** | Vault search, questions about notes, "find", "where did I put" |
+| 5 | **architect** | Vault structure, areas, templates, MOCs, tags (NOT onboarding, defrag, or agent creation — those are skills) |
+| 6 | **sorter** | Smart batch, priority triage, project pulse (NOT standard inbox triage — that's a skill) |
+| 7 | **connector** | Links between notes, graph, MOCs, relationships, cross-linking |
+| 8 | **librarian** | Quick health check, consistency report, growth analytics, stale content (NOT full audit, deep clean, or tag garden — those are skills) |
+| 9+ | **custom agents** | Any agent created via the Architect. Check `.codex/references/agents-registry.md` for triggers and capabilities. Custom agents always have lower priority than core 8. |
+
+---
+
+## 1. POSTMAN (agent)
+
+Activate for calendar operations and simple email interactions NOT covered by skills.
+
+Triggers: "import events", "what's on my calendar", "create event", "postman", "VIP emails", "draft reply", "travel plan", "invoice tracker", "targeted email search", "calendar search"
+
+> **Note**: email triage → `/email-triage` skill. Meeting prep → `/meeting-prep` skill. Weekly agenda → `/weekly-agenda` skill. Deadlines → `/deadline-radar` skill.
+
+---
+
+## 2. TRANSCRIBER (agent)
+
+Activate only for edge cases not covered by the `/transcribe` skill.
+
+> **Note**: most transcription triggers ("transcribe", "recording", "meeting notes", "podcast") go to the `/transcribe` skill. The agent handles only direct follow-up or edge cases.
+
+---
+
+## 3. SCRIBE (agent)
+
+Activate when the user wants to capture/save information to the vault.
+
+Triggers: "save this", "jot this down", "quick note", "write this", "remind me that", "note this", "capture this", "voice note", "brainstorm", "reading notes", "quote", "take note", "mark this down", "quick idea", "I have a thought", "write a note about", "gratitude journal", "gratitude", "what am I grateful for today", "evening gratitude"
+
+Also activate when the user pastes unstructured text, does speech-to-text, or dumps a list of thoughts.
+
+---
+
+## 4. SEEKER (agent)
+
+Activate for any search or question about vault content.
+
+Triggers: "search the vault", "find", "where did I put", "what notes do I have on", "what do we know about", "show me", "edit the note on", "update the note", "find and edit", "answer from my notes", "timeline", "compare", "what am I missing", "what should I revisit", "search", "show me", "what info do I have on"
+
+---
+
+## 5. ARCHITECT (agent)
+
+Activate for reactive vault structure operations NOT covered by skills.
+
+Triggers: "create a new area", "new project", "add template", "modify the structure", "new folder", "tag taxonomy", "naming convention", "create a MOC", "restructure the vault", "add an area", "fix the structure"
+
+Also activate: when another agent reports missing structure; when a new topic/project/area emerges.
+
+> **Note**: onboarding → `/onboarding` skill. Agent creation → `/create-agent` skill. Agent management → `/manage-agent` skill. Defrag → `/defrag` skill.
+
+---
+
+## 6. SORTER (agent)
+
+Activate for sorting modes NOT covered by the `/inbox-triage` skill.
+
+Triggers: "batch sort", "priority triage", "project pulse", "evening triage"
+
+> **Note**: standard inbox triage ("triage the inbox", "empty inbox", "sort my notes") → `/inbox-triage` skill.
+
+---
+
+## 7. CONNECTOR (agent)
+
+Activate for link analysis and knowledge graph work.
+
+Triggers: "connect the notes", "find connections", "improve the graph", "what connections are missing", "strengthen links", "analyze relationships", "network analysis", "serendipity", "constellation", "bridge notes", "people network", "graph health", "missing links"
+
+---
+
+## 8. LIBRARIAN (agent)
+
+Activate for quick checks and analytics NOT covered by skills.
+
+Triggers: "quick check", "consistency report", "growth analytics", "stale content", "are there duplicates?", "maintenance"
+
+> **Note**: full audit → `/vault-audit` skill. Deep clean → `/deep-clean` skill. Tag garden → `/tag-garden` skill.
+
+---
+
+## 9. CUSTOM AGENTS
+
+Custom agents are created via the `/create-agent` skill and stored in `.codex/agents/`. They are auto-discovered by Codex CLI like core agents. When a user message does not match any skill or core agent, check `.codex/references/agents-registry.md` for custom agents whose Input column matches the message. If a match is found, delegate to that agent.
+
+---
+
+## Multi-agent routing
+
+The dispatcher is a **reactive multi-router**. After invoking an agent, analyze its output before responding to the user:
+
+1. Did the agent create content that needs filing? → Consider **Sorter**
+2. Did the agent report missing structure? → Consider **Architect**
+3. Did the agent find notes that need linking? → Consider **Connector**
+4. Did the agent produce notes that need cleanup? → Consider **Librarian**
+5. Did the agent include a `### Suggested next agent` section? → Validate and consider it
+6. Did the agent include a `### Suggested new agent` section? → Ask the user if they want the **Architect** to create a custom agent for the detected need
+
+Consult `.codex/references/agents-registry.md` to validate suggestions and match output to agent capabilities.
+
+### Call chain tracking
+
+Maintain a call chain for each user request:
+
+1. Start with an empty chain: `[]`
+2. After each agent returns, append its name to the chain (the chain always lists agents already invoked, in order)
+3. When invoking the next agent, pass the chain and position, e.g.: `"Call chain so far: [scribe, architect]. You are step 3 of max 3."`
+4. After the agent returns, read its output and decide if another agent is needed
+
+### Anti-recursion rules
+
+- **No duplicates**: never invoke the same agent twice in one user request
+- **No circular chains**: if Agent A's output suggests Agent B, and B is already in the chain, skip it
+- **Max depth 3**: no more than 3 agents per user request
+- **On overflow**: return results to the user and suggest what they can do next (e.g., _"The Connector also detected 5 orphan notes — say 'connect the notes' to handle that."_)
+
+### Decision flow
+
+```
+USER MESSAGE → check SKILL routing table first
+           ↓
+  Skill match found? → INVOKE skill (skills system) → RESPOND to user
+           ↓ (no skill match)
+  Check AGENT routing table → INVOKE agent (spawn_agent tool)
+           ↓
+     READ OUTPUT → check agents-registry.md
+           ↓
+  Does output match another agent's capabilities?
+     YES + not in chain + depth < 3 → INVOKE next
+     NO or limit reached → RESPOND to user
+```
+
+---
+
+## Inter-agent coordination
+
+Agents do NOT communicate directly with each other. The dispatcher orchestrates all agent calls.
+
+When an agent detects work for another agent (e.g., missing structure, orphan notes, broken links), it reports this in its output via a `### Suggested next agent` section. The dispatcher reads this and decides whether to chain the next agent.
+
+See `.codex/references/agent-orchestration.md` for the full protocol and `.codex/references/agents-registry.md` for the agent registry.
+
+---
+
+# Project Info
+
+## My Brain Is Full - Crew
+
+A crew of 8 AI subagents that manage an Obsidian vault through natural conversation.
+
+## Installation
+
+### Step 1: Create your Obsidian vault
+
+If you don't have one yet, open [Obsidian](https://obsidian.md) and create a new vault.
+
+### Step 2: Clone the repo inside your vault
+
+```bash
+cd /path/to/your-vault
+git clone https://github.com/gnekt/My-Brain-Is-Full-Crew.git
+```
+
+### Step 3: Run the installer
+
+```bash
+cd My-Brain-Is-Full-Crew
+bash scripts/launchme-codex.sh
+```
+
+The script asks a couple of questions and copies everything into `.codex/` inside your vault:
+
+```
+your-vault/
+├── .codex/
+│   ├── agents/          ← 8 crew agents (auto-loaded by Codex CLI)
+│   └── references/      ← shared docs the agents read
+├── .mcp.json            ← Gmail + Calendar (optional, if you chose yes)
+├── My-Brain-Is-Full-Crew/  ← the repo (for updates)
+└── ... your notes
+```
+
+### Step 4: Initialize
+
+1. Open Codex CLI **inside your vault folder**
+2. Say: **"Initialize my vault"**
+3. The Architect agent runs onboarding — creates your folder structure, templates, and preferences
+
+### Updating
+
+```bash
+cd /path/to/your-vault/My-Brain-Is-Full-Crew
+git pull
+bash scripts/updateme-codex.sh
+```
+
+Only changed files are overwritten. Your vault notes are never touched.
+
+## Requirements
+
+- **Codex CLI** with a Claude Pro, Max, or Team subscription
+- **Obsidian** (free) — [obsidian.md](https://obsidian.md)
+- **Gmail / Google Calendar** (optional) — only for the Postman agent
+
+## Project Structure
+
+```
+My-Brain-Is-Full-Crew/
+├── agents/                   The 8 subagents
+│   ├── architect.md            Vault setup & onboarding
+│   ├── scribe.md               Text capture & note creation
+│   ├── sorter.md               Inbox triage & filing
+│   ├── seeker.md               Search & knowledge retrieval
+│   ├── connector.md            Knowledge graph & link analysis
+│   ├── librarian.md            Vault health & maintenance
+│   ├── transcriber.md          Audio & meeting transcription
+│   └── postman.md              Email & calendar integration
+├── references/               Shared agent documentation
+├── docs/                     User-facing documentation
+├── scripts/
+│   ├── launchme-codex.sh             First-time installer
+│   └── updateme-codex.sh             Post-pull updater
+├── .codex-plugin/plugin.json  Plugin manifest (for --plugin-dir)
+├── .mcp.json                 MCP servers (Gmail, Google Calendar)
+├── README.md
+├── CONTRIBUTING.md
+└── LICENSE
+```
+
+## Language
+
+All agent files are written in English. Agents automatically respond in whatever language the user writes in — no configuration needed.
+
+## Architecture
+
+Each agent is defined in `.codex/agents/{name}.md` (in the destination vault) with YAML frontmatter (`name`, `description`, `tools`, `model`) and a full system prompt body. Codex CLI auto-discovers these agents at session start, reads their `description` field, and delegates automatically when the user's message matches.
+
+The AGENTS.md routing rules REINFORCE this auto-delegation — they provide explicit priority ordering and trigger lists to ensure Claude delegates correctly.
+
+Key design decisions:
+
+- **Seeker** is search-only (`tools: Read, Glob, Grep`) — it finds information but doesn't modify notes
+- **Architect** and **Librarian** have full access including Bash for structural operations
+- **Postman** uses Gmail and Google Calendar via MCP servers defined in `.mcp.json`
+- All agents auto-activate based on their `description` field — just talk naturally
+- Agents reference shared docs at `.codex/references/`
+
+## Alternative: load as plugin (CLI)
+
+If you prefer not to clone into the vault:
+
+```bash
+claude --plugin-dir /path/to/My-Brain-Is-Full-Crew
+```
+
+This loads agents + MCP for the current session. You still need to run `launchme-codex.sh` to set up `.codex/references/` in the vault.
+
+## Development
+
+```bash
+claude --plugin-dir ./
+```
+
+Use `/reload-plugins` to pick up changes without restarting.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,7 +305,7 @@ All agent files are written in English. Agents automatically respond in whatever
 
 Each agent is defined in `.codex/agents/{name}.md` (in the destination vault) with YAML frontmatter (`name`, `description`, `tools`, `model`) and a full system prompt body. Codex CLI auto-discovers these agents at session start, reads their `description` field, and delegates automatically when the user's message matches.
 
-The AGENTS.md routing rules REINFORCE this auto-delegation — they provide explicit priority ordering and trigger lists to ensure Claude delegates correctly.
+The AGENTS.md routing rules REINFORCE this auto-delegation — they provide explicit priority ordering and trigger lists to ensure the Codex runtime delegates to the correct agents.
 
 Key design decisions:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,6 +244,7 @@ The script asks a couple of questions and copies everything into `.codex/` insid
 your-vault/
 ├── .codex/
 │   ├── agents/          ← 8 crew agents (auto-loaded by Codex CLI)
+│   ├── skills/          ← 13 crew skills
 │   └── references/      ← shared docs the agents read
 ├── .mcp.json            ← Gmail + Calendar (optional, if you chose yes)
 ├── My-Brain-Is-Full-Crew/  ← the repo (for updates)
@@ -285,12 +286,14 @@ My-Brain-Is-Full-Crew/
 │   ├── librarian.md            Vault health & maintenance
 │   ├── transcriber.md          Audio & meeting transcription
 │   └── postman.md              Email & calendar integration
+├── skills/                   The 13 specialized skills
 ├── references/               Shared agent documentation
 ├── docs/                     User-facing documentation
 ├── scripts/
-│   ├── launchme-codex.sh             First-time installer
-│   └── updateme-codex.sh             Post-pull updater
-├── .codex-plugin/plugin.json  Plugin manifest (for --plugin-dir)
+│   ├── launchme-codex.sh       First-time Codex installer
+│   ├── updateme-codex.sh       Post-pull Codex updater
+│   └── lib/codex-transform.sh  Codex text transformation helpers
+├── AGENTS.md                 Codex dispatcher instructions
 ├── .mcp.json                 MCP servers (Gmail, Google Calendar)
 ├── README.md
 ├── CONTRIBUTING.md
@@ -311,25 +314,16 @@ Key design decisions:
 
 - **Seeker** is search-only (`tools: Read, Glob, Grep`) — it finds information but doesn't modify notes
 - **Architect** and **Librarian** have full access including Bash for structural operations
-- **Postman** uses Gmail and Google Calendar via MCP servers defined in `.mcp.json`
+- **Postman** uses email (Gmail via `gws`, Hey.com via `hey` CLI) and Google Calendar for full read/write access, with MCP servers (`.mcp.json`) as a read-only fallback. See `docs/gws-setup-guide.md` for GWS setup
 - All agents auto-activate based on their `description` field — just talk naturally
 - Agents reference shared docs at `.codex/references/`
 
-## Alternative: load as plugin (CLI)
-
-If you prefer not to clone into the vault:
-
-```bash
-claude --plugin-dir /path/to/My-Brain-Is-Full-Crew
-```
-
-This loads agents + MCP for the current session. You still need to run `launchme-codex.sh` to set up `.codex/references/` in the vault.
-
 ## Development
 
+To test changes locally, run the Codex installer from the repo:
+
 ```bash
-claude --plugin-dir ./
+bash scripts/launchme-codex.sh
 ```
 
-Use `/reload-plugins` to pick up changes without restarting.
-
+After modifying agent or skill files, re-run `updateme-codex.sh` to push changes into the vault's `.codex/` directory.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <img src="https://img.shields.io/badge/Agents-8%2B-blueviolet?style=flat-square" alt="8+ Agents" />
   <img src="https://img.shields.io/badge/Skills-13-blue?style=flat-square" alt="13 Skills" />
   <img src="https://img.shields.io/badge/Language-Any-success?style=flat-square" alt="Any Language" />
-  <img src="https://img.shields.io/badge/Platform-Obsidian%20%2B%20Claude-blue?style=flat-square" alt="Obsidian + Claude" />
+  <img src="https://img.shields.io/badge/Platform-Obsidian%20%2B%20Claude%20%2B%20Codex-blue?style=flat-square" alt="Obsidian + Claude + Codex" />
   <img src="https://img.shields.io/badge/License-MIT-yellow?style=flat-square" alt="MIT License" />
 </p>
 
@@ -233,16 +233,16 @@ sequenceDiagram
     S->>S: files notes to correct locations
 ```
 
-### Works on both Claude Code CLI and Claude Code Desktop (Cowork)
+### Works on Claude Code and Codex CLI
 
-The installer sets up **two parallel layers** so the Crew works everywhere:
+The installers set up parallel runtime layers so the Crew works in both environments:
 
 | Layer | Location | Purpose |
 |-------|----------|---------|
-| **Agents** | `.claude/agents/` | Lightweight reactive agents for single-shot tasks (capture, search, create) |
-| **Skills** | `.claude/skills/` | Specialized multi-step flows for complex tasks (onboarding, triage, audits) |
+| **Claude runtime** | `.claude/agents/`, `.claude/skills/`, `.claude/references/`, `CLAUDE.md` | Claude-native dispatcher + crew runtime |
+| **Codex runtime** | `.codex/agents/`, `.codex/skills/`, `.codex/references/`, `AGENTS.md` | Codex-native dispatcher + crew runtime |
 
-Both layers work on CLI and Desktop. `launchme.sh` installs both automatically. The dispatcher decides whether to invoke a skill or an agent based on your message.
+Use `launchme.sh` for Claude setup and `launchme-codex.sh` or `launchme-codex.ps1` for Codex setup.
 
 Your vault follows a hybrid **PARA + Zettelkasten** structure:
 
@@ -264,7 +264,7 @@ Meta/              Vault config, agent logs, health reports
 
 ## Quick start
 
-> **Prerequisite**: You need [Claude Code](https://claude.ai/code) with a Claude Pro, Max, or Team subscription, and [Obsidian](https://obsidian.md) (free).
+> **Prerequisite**: You need [Obsidian](https://obsidian.md) and at least one runtime: [Claude Code](https://claude.ai/code) or Codex CLI.
 
 ### 1. Create your Obsidian vault
 
@@ -277,20 +277,34 @@ cd /path/to/your-vault
 git clone https://github.com/gnekt/My-Brain-Is-Full-Crew.git
 ```
 
-### 3. Run the installer
+### 3. Run the installer for your runtime
 
 ```bash
 cd My-Brain-Is-Full-Crew
 bash scripts/launchme.sh
 ```
 
-The script asks a couple of questions and copies the agents and skills into your vault's `.claude/` directory. That's it. When Claude Code is open in your vault folder, the agents activate automatically. When you're in any other project, they don't.
+For Codex CLI:
+
+```bash
+cd My-Brain-Is-Full-Crew
+bash scripts/launchme-codex.sh
+```
+
+For Windows PowerShell (Codex):
+
+```powershell
+cd My-Brain-Is-Full-Crew
+powershell -ExecutionPolicy Bypass -File scripts/launchme-codex.ps1
+```
+
+Claude installer writes `.claude/*` + `CLAUDE.md`. Codex installer writes `.codex/*` + `AGENTS.md`.
 
 > **Never used a terminal before?** See the [step-by-step guide for beginners](docs/getting-started.md). It walks you through everything, or just show this page to a tech-savvy friend. It takes 60 seconds.
 
 ### 4. Initialize
 
-Open Claude Code **inside your vault folder** and say:
+Open your selected runtime **inside your vault folder** and say:
 
 > **"Initialize my vault"**
 
@@ -360,7 +374,11 @@ The **Postman** agent (and its related skills: `/email-triage`, `/meeting-prep`,
 - **Hey CLI** (`hey`) — for Hey.com accounts. Read/reply/compose emails, leverages Hey's pre-sorted mailboxes (Imbox, Feed, Paper Trail, Reply Later, Set Aside, Bubble Up). Calendar operations still use `gws`. See [Hey CLI](https://github.com/basecamp/hey-cli) for installation.
 - **MCP connectors** (read-only fallback) — `launchme.sh` offers to set up `.mcp.json` automatically. Limited to reading emails and calendar events, plus draft creation.
 
-You can use `gws` and `hey` simultaneously if you have both Gmail and Hey.com accounts. All other agents and skills work with just your local Obsidian vault. No integrations needed.
+You can use `gws` and `hey` simultaneously if you have both Gmail and Hey.com accounts.
+
+Both installer paths can set up `.mcp.json`. You still need to authorize connectors in your runtime client.
+
+All other agents and skills work with just your local Obsidian vault. No integrations needed.
 
 ### Updating
 
@@ -370,6 +388,14 @@ After pulling new changes from the repo:
 cd /path/to/your-vault/My-Brain-Is-Full-Crew
 git pull
 bash scripts/updateme.sh
+```
+
+For Codex CLI updates:
+
+```bash
+cd /path/to/your-vault/My-Brain-Is-Full-Crew
+git pull
+bash scripts/updateme-codex.sh
 ```
 
 Only changed files are updated. Your vault notes are never touched.
@@ -426,6 +452,8 @@ My-Brain-Is-Full-Crew/               ← cloned inside your vault
 └── CONTRIBUTING.md
 ```
 
+Codex runtime scripts and helpers are in `scripts/launchme-codex.sh`, `scripts/updateme-codex.sh`, `scripts/launchme-codex.ps1`, `scripts/updateme-codex.ps1`, and `scripts/lib/`.
+
 After running `launchme.sh`, your vault looks like:
 
 ```
@@ -435,7 +463,9 @@ your-vault/
 │   ├── skills/          ← specialized multi-step skills
 │   └── references/      ← shared docs
 ├── CLAUDE.md            ← project instructions (dispatcher routing)
-├── .mcp.json            ← Gmail + Calendar read-only fallback (if enabled)
+├── .codex/              ← Codex runtime mirror (agents, skills, references)
+├── AGENTS.md            ← Codex dispatcher instructions
+├── .mcp.json            ← Gmail + Calendar (if enabled)
 ├── My-Brain-Is-Full-Crew/  ← the repo (for updates)
 └── ... your Obsidian notes
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@ A step-by-step guide for setting up your AI-powered vault. No technical backgrou
 
 ### Required
 - **Obsidian**: A free note-taking app. Download it at [obsidian.md](https://obsidian.md)
-- **Claude Code**: Anthropic's coding assistant. You need a Claude Pro, Max, or Team subscription.
+- **One runtime**: Claude Code (Pro/Max/Team) or Codex CLI
 - **An Obsidian vault**: This is just a folder on your computer where Obsidian stores your notes. If you don't have one yet, Obsidian will create one for you when you first open it.
 - **Git**: A tool to download the project. On Mac, the terminal will prompt you to install it automatically the first time you use it. On Windows, download it from [git-scm.com](https://git-scm.com).
 
@@ -57,11 +57,11 @@ Don't worry if this feels like a lot. The Architect agent will remind you about 
 
 ---
 
-## Step 2: Install Claude Code
+## Step 2: Install your runtime
 
-1. Go to [claude.ai/code](https://claude.ai/code) and follow the instructions to install Claude Code
-2. You need a **Claude Pro**, **Max**, or **Team** subscription
-3. You can use either the **Desktop app** (Cowork) or the **CLI** (command-line interface). The Crew works on both
+1. If you use Claude: go to [claude.ai/code](https://claude.ai/code) and install Claude Code
+2. If you use Codex: install Codex CLI in your environment
+3. You can set up both in the same vault; each runtime has its own installer path
 
 ---
 
@@ -81,11 +81,25 @@ Clone the repo inside your vault:
 git clone https://github.com/gnekt/My-Brain-Is-Full-Crew.git
 ```
 
-Run the installer:
+Run the installer for your runtime:
 
 ```bash
 cd My-Brain-Is-Full-Crew
 bash scripts/launchme.sh
+```
+
+For Codex CLI:
+
+```bash
+cd My-Brain-Is-Full-Crew
+bash scripts/launchme-codex.sh
+```
+
+For Windows PowerShell (Codex):
+
+```powershell
+cd My-Brain-Is-Full-Crew
+powershell -ExecutionPolicy Bypass -File scripts/launchme-codex.ps1
 ```
 
 The script will ask two quick questions:
@@ -101,6 +115,8 @@ your-vault/
 │   ├── skills/          ← 13 specialized skills for complex flows
 │   └── references/      ← shared docs the agents read
 ├── CLAUDE.md            ← project instructions
+├── .codex/              ← Codex runtime mirror (agents, skills, references)
+├── AGENTS.md            ← Codex dispatcher instructions
 ├── .mcp.json            ← Gmail + Calendar (only if you said yes)
 ├── My-Brain-Is-Full-Crew/  ← the repo (for future updates)
 └── ... your Obsidian notes
@@ -112,8 +128,8 @@ your-vault/
 
 ## Step 4: Connect your vault
 
-1. Open Claude Code (CLI or Desktop)
-2. Open it **inside your Obsidian vault folder**. This is important: Claude needs to be in your vault to read and write your notes.
+1. Open your runtime (Claude Code or Codex CLI)
+2. Open it **inside your Obsidian vault folder** so it can read and write notes.
 
 If you're using the CLI:
 ```bash
@@ -211,7 +227,7 @@ The Crew works best with simple daily routines:
 ## Troubleshooting
 
 ### "The agent doesn't seem to activate"
-Make sure Claude Code is open inside your vault folder (not a different directory). Verify agent files exist at `.claude/agents/` and skill files at `.claude/skills/` in your vault. Try saying the trigger phrase differently. Agents and skills understand natural language in multiple languages.
+Make sure your runtime is open inside your vault folder (not a different directory). For Claude, verify `.claude/agents/` and `.claude/skills/`. For Codex, verify `.codex/agents/` and `.codex/skills/` plus `AGENTS.md`. Try saying the trigger phrase differently. Agents and skills understand natural language in multiple languages.
 
 ### "Email/Calendar isn't working"
 The Postman needs at least one email backend: GWS CLI (`gws`), Hey CLI (`hey`), or MCP connectors. For GWS, see `docs/gws-setup-guide.md`. For Hey, install from [github.com/basecamp/hey-cli](https://github.com/basecamp/hey-cli) and run `hey auth login`. For MCP, run the installer again (`bash scripts/launchme.sh`) and answer **yes** to the Gmail/Calendar question, or manually copy `.mcp.json` from the repo to your vault root.
@@ -225,6 +241,14 @@ The Architect customizes the structure based on your onboarding answers.
 cd /path/to/your-vault/My-Brain-Is-Full-Crew
 git pull
 bash scripts/updateme.sh
+```
+
+For Codex:
+
+```bash
+cd /path/to/your-vault/My-Brain-Is-Full-Crew
+git pull
+bash scripts/updateme-codex.sh
 ```
 
 Only changed files are updated. Your vault notes are never touched.

--- a/scripts/launchme-codex.ps1
+++ b/scripts/launchme-codex.ps1
@@ -54,6 +54,8 @@ if (Test-Path -LiteralPath $oldManifest) {
     $depPath = Join-Path $depDir $depName
     if (Test-Path -LiteralPath $depPath) { continue }
     Move-Item -LiteralPath $dst -Destination $depPath
+    $depContent = Get-Content -Raw -LiteralPath $depPath
+    Set-Content -LiteralPath $depPath -Value ("########`nDEPRECATED DO NOT USE`n########`n`n" + $depContent)
     Warn "Deprecated stale Codex agent: $oldName"
   }
 }

--- a/scripts/launchme-codex.ps1
+++ b/scripts/launchme-codex.ps1
@@ -1,0 +1,147 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. "$PSScriptRoot/lib/CodexTransform.ps1"
+
+$repoDir = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$vaultDir = (Resolve-Path (Join-Path $repoDir '..')).Path
+
+function Info([string]$msg) { Write-Host "[INFO] $msg" }
+function Ok([string]$msg) { Write-Host "[OK]   $msg" }
+function Warn([string]$msg) { Write-Host "[WARN] $msg" }
+
+if (-not (Test-Path -LiteralPath (Join-Path $repoDir 'agents'))) { throw 'Missing agents/' }
+if (-not (Test-Path -LiteralPath (Join-Path $repoDir 'references'))) { throw 'Missing references/' }
+if (-not (Test-Path -LiteralPath (Join-Path $repoDir 'AGENTS.md'))) { throw 'Missing AGENTS.md' }
+
+Write-Host 'Codex installer (PowerShell)'
+Write-Host "Repo:  $repoDir"
+Write-Host "Vault: $vaultDir"
+
+$confirm = Read-Host 'Install to this vault path? [Y/n]'
+if ($confirm -match '^[Nn]$') {
+  $vaultDir = Read-Host 'Enter full vault path'
+  if (-not (Test-Path -LiteralPath $vaultDir)) { throw "Directory not found: $vaultDir" }
+}
+
+$existing = Test-Path -LiteralPath (Join-Path $vaultDir '.codex')
+if ($existing) {
+  Warn 'Existing .codex installation found.'
+  $answer = Read-Host 'Continue and overwrite core Codex files? [c/q]'
+  if ($answer -notmatch '^[Cc]$') {
+    Info 'Installation cancelled'
+    exit 0
+  }
+}
+
+$codexDir = Join-Path $vaultDir '.codex'
+$agentsDir = Join-Path $codexDir 'agents'
+$refsDir = Join-Path $codexDir 'references'
+$skillsDir = Join-Path $codexDir 'skills'
+New-Item -ItemType Directory -Force -Path $agentsDir, $refsDir, $skillsDir | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $vaultDir 'Meta/states') | Out-Null
+
+$oldManifest = Join-Path $agentsDir '.core-manifest'
+if (Test-Path -LiteralPath $oldManifest) {
+  foreach ($oldName in Get-Content -LiteralPath $oldManifest) {
+    if ([string]::IsNullOrWhiteSpace($oldName)) { continue }
+    if (Test-Path -LiteralPath (Join-Path $repoDir "agents/$oldName")) { continue }
+    $dst = Join-Path $agentsDir $oldName
+    if (-not (Test-Path -LiteralPath $dst)) { continue }
+    $depDir = Join-Path $codexDir 'deprecated'
+    New-Item -ItemType Directory -Force -Path $depDir | Out-Null
+    $depName = [IO.Path]::GetFileNameWithoutExtension($oldName) + '-DEPRECATED.md'
+    $depPath = Join-Path $depDir $depName
+    if (Test-Path -LiteralPath $depPath) { continue }
+    Move-Item -LiteralPath $dst -Destination $depPath
+    Warn "Deprecated stale Codex agent: $oldName"
+  }
+}
+
+$manifestLines = New-Object System.Collections.Generic.List[string]
+$agentCount = 0
+Get-ChildItem -LiteralPath (Join-Path $repoDir 'agents') -Filter *.md -File | ForEach-Object {
+  $dst = Join-Path $agentsDir $_.Name
+  Convert-ToCodexFile -SourcePath $_.FullName -DestinationPath $dst
+  $manifestLines.Add($_.Name)
+  $agentCount++
+}
+Set-Content -LiteralPath $oldManifest -Value $manifestLines
+Ok "Installed $agentCount Codex agents"
+
+$userMutable = @('agents-registry.md', 'agents.md')
+$refManifest = Join-Path $refsDir '.core-manifest'
+$refLines = New-Object System.Collections.Generic.List[string]
+$refCount = 0
+Get-ChildItem -LiteralPath (Join-Path $repoDir 'references') -Filter *.md -File | ForEach-Object {
+  $name = $_.Name
+  $dst = Join-Path $refsDir $name
+  if ($existing -and (Test-Path -LiteralPath $dst) -and $userMutable.Contains($name)) {
+    Warn "Preserving existing $name"
+    $refLines.Add($name)
+    return
+  }
+  Convert-ToCodexFile -SourcePath $_.FullName -DestinationPath $dst
+  $refLines.Add($name)
+  $refCount++
+}
+Set-Content -LiteralPath $refManifest -Value $refLines
+Ok "Installed/updated $refCount Codex references"
+
+$skillCount = 0
+Get-ChildItem -LiteralPath (Join-Path $repoDir 'skills') -Directory | ForEach-Object {
+  $skillFile = Join-Path $_.FullName 'SKILL.md'
+  if (-not (Test-Path -LiteralPath $skillFile)) { return }
+  $skillDstDir = Join-Path $skillsDir $_.Name
+  New-Item -ItemType Directory -Force -Path $skillDstDir | Out-Null
+  Convert-ToCodexFile -SourcePath $skillFile -DestinationPath (Join-Path $skillDstDir 'SKILL.md')
+  $skillCount++
+}
+Ok "Installed $skillCount Codex skills"
+
+$managedHeader = '<!-- managed-by: my-brain-is-full-crew -->'
+$generatedAgents = Join-Path $codexDir 'AGENTS.generated.md'
+$baseAgents = Get-Content -Raw -LiteralPath (Join-Path $repoDir 'AGENTS.md')
+Set-Content -LiteralPath $generatedAgents -Value ($managedHeader + [Environment]::NewLine + $baseAgents)
+
+$vaultAgents = Join-Path $vaultDir 'AGENTS.md'
+if (Test-Path -LiteralPath $vaultAgents) {
+  $existingAgents = Get-Content -Raw -LiteralPath $vaultAgents
+  if ($existingAgents.Contains($managedHeader)) {
+    Copy-Item -LiteralPath $generatedAgents -Destination $vaultAgents -Force
+    Ok 'Updated managed AGENTS.md'
+  } else {
+    Warn 'Found existing unmanaged AGENTS.md'
+    $a = Read-Host 'Overwrite vault AGENTS.md with Crew dispatcher? [o/s]'
+    if ($a -match '^[Oo]$') {
+      Copy-Item -LiteralPath $generatedAgents -Destination $vaultAgents -Force
+      Ok 'Overwrote AGENTS.md'
+    } else {
+      Copy-Item -LiteralPath $generatedAgents -Destination (Join-Path $vaultDir 'AGENTS.crew.md') -Force
+      Warn 'Wrote AGENTS.crew.md instead'
+    }
+  }
+} else {
+  Copy-Item -LiteralPath $generatedAgents -Destination $vaultAgents -Force
+  Ok 'Installed AGENTS.md'
+}
+Remove-Item -LiteralPath $generatedAgents -Force
+
+$mcpAnswer = Read-Host 'Set up Gmail + Google Calendar MCP (.mcp.json)? [y/N]'
+if ($mcpAnswer -match '^[Yy]$') {
+  $vaultMcp = Join-Path $vaultDir '.mcp.json'
+  if (Test-Path -LiteralPath $vaultMcp) {
+    Warn '.mcp.json already exists, not overwriting'
+  } else {
+    Copy-Item -LiteralPath (Join-Path $repoDir '.mcp.json') -Destination $vaultMcp
+    Ok 'Created .mcp.json'
+  }
+}
+
+Write-Host ''
+Write-Host 'Codex setup complete.'
+Write-Host "Installed to: $codexDir"
+Write-Host 'Next steps:'
+Write-Host '1) Open Codex CLI inside the vault folder'
+Write-Host '2) Ensure AGENTS.md (or AGENTS.crew.md) is active for this vault'
+Write-Host '3) Start with: Initialize my vault'

--- a/scripts/launchme-codex.sh
+++ b/scripts/launchme-codex.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# =============================================================================
+# My Brain Is Full - Crew :: Codex Installer
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+VAULT_DIR="$(cd "$REPO_DIR/.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$REPO_DIR/scripts/lib/codex-transform.sh"
+
+info()    { echo "[INFO] $*"; }
+success() { echo "[OK]   $*"; }
+warn()    { echo "[WARN] $*"; }
+die()     { echo "[ERR]  $*" >&2; exit 1; }
+
+[[ -d "$REPO_DIR/agents" ]] || die "Missing agents/ in repository"
+[[ -d "$REPO_DIR/references" ]] || die "Missing references/ in repository"
+[[ -f "$REPO_DIR/AGENTS.md" ]] || die "Missing AGENTS.md in repository"
+
+echo "Codex installer"
+echo "Repo:  $REPO_DIR"
+echo "Vault: $VAULT_DIR"
+
+read -r -p "Install to this vault path? [Y/n]: " CONFIRM || true
+if [[ "${CONFIRM:-y}" =~ ^[Nn]$ ]]; then
+  read -r -p "Enter full vault path: " VAULT_DIR || die "Unable to read vault path"
+  [[ -d "$VAULT_DIR" ]] || die "Directory not found: $VAULT_DIR"
+fi
+
+EXISTING=0
+[[ -d "$VAULT_DIR/.codex" ]] && EXISTING=1
+
+if [[ $EXISTING -eq 1 ]]; then
+  warn "Existing .codex installation found."
+  read -r -p "Continue and overwrite core Codex files? [c/q]: " OVERWRITE_ANSWER || true
+  [[ "${OVERWRITE_ANSWER:-q}" =~ ^[Cc]$ ]] || { info "Installation cancelled"; exit 0; }
+fi
+
+mkdir -p "$VAULT_DIR/.codex/agents" "$VAULT_DIR/.codex/references" "$VAULT_DIR/.codex/skills"
+
+# Deprecate removed core agents using old manifest
+OLD_MANIFEST="$VAULT_DIR/.codex/agents/.core-manifest"
+if [[ -f "$OLD_MANIFEST" ]]; then
+  while IFS= read -r old_name; do
+    [[ -z "$old_name" ]] && continue
+    [[ -f "$REPO_DIR/agents/$old_name" ]] && continue
+    dst="$VAULT_DIR/.codex/agents/$old_name"
+    [[ -f "$dst" ]] || continue
+    mkdir -p "$VAULT_DIR/.codex/deprecated"
+    deprecated_name="${old_name%.md}-DEPRECATED.md"
+    [[ -f "$VAULT_DIR/.codex/deprecated/$deprecated_name" ]] && continue
+    mv "$dst" "$VAULT_DIR/.codex/deprecated/$deprecated_name"
+    warn "Deprecated stale Codex agent: $old_name"
+  done < "$OLD_MANIFEST"
+fi
+
+# Copy core agents (transformed)
+: > "$VAULT_DIR/.codex/agents/.core-manifest"
+AGENT_COUNT=0
+for agent in "$REPO_DIR/agents/"*.md; do
+  name="$(basename "$agent")"
+  render_for_codex_file "$agent" "$VAULT_DIR/.codex/agents/$name"
+  echo "$name" >> "$VAULT_DIR/.codex/agents/.core-manifest"
+  AGENT_COUNT=$((AGENT_COUNT + 1))
+done
+success "Installed $AGENT_COUNT Codex agents"
+
+mkdir -p "$VAULT_DIR/Meta/states"
+
+# Copy references (preserve mutable refs on reinstall)
+USER_MUTABLE_REFS="agents-registry.md agents.md"
+: > "$VAULT_DIR/.codex/references/.core-manifest"
+REF_COUNT=0
+for ref in "$REPO_DIR/references/"*.md; do
+  ref_name="$(basename "$ref")"
+  dst="$VAULT_DIR/.codex/references/$ref_name"
+  if [[ $EXISTING -eq 1 && -f "$dst" && " $USER_MUTABLE_REFS " == *" $ref_name "* ]]; then
+    warn "Preserving existing $ref_name"
+    echo "$ref_name" >> "$VAULT_DIR/.codex/references/.core-manifest"
+    continue
+  fi
+  render_for_codex_file "$ref" "$dst"
+  echo "$ref_name" >> "$VAULT_DIR/.codex/references/.core-manifest"
+  REF_COUNT=$((REF_COUNT + 1))
+done
+success "Installed/updated $REF_COUNT Codex references"
+
+# Copy skills (transformed)
+SKILL_COUNT=0
+if [[ -d "$REPO_DIR/skills" ]]; then
+  for skill_dir in "$REPO_DIR/skills/"*/; do
+    [[ -f "$skill_dir/SKILL.md" ]] || continue
+    skill_name="$(basename "$skill_dir")"
+    mkdir -p "$VAULT_DIR/.codex/skills/$skill_name"
+    render_for_codex_file "$skill_dir/SKILL.md" "$VAULT_DIR/.codex/skills/$skill_name/SKILL.md"
+    SKILL_COUNT=$((SKILL_COUNT + 1))
+  done
+fi
+success "Installed $SKILL_COUNT Codex skills"
+
+# Install AGENTS.md with conflict prompt
+MANAGED_HEADER="<!-- managed-by: my-brain-is-full-crew -->"
+TMP_AGENTS="$VAULT_DIR/.codex/AGENTS.generated.md"
+printf '%s\n' "$MANAGED_HEADER" > "$TMP_AGENTS"
+cat "$REPO_DIR/AGENTS.md" >> "$TMP_AGENTS"
+
+if [[ -f "$VAULT_DIR/AGENTS.md" ]]; then
+  if grep -qF "$MANAGED_HEADER" "$VAULT_DIR/AGENTS.md"; then
+    cp "$TMP_AGENTS" "$VAULT_DIR/AGENTS.md"
+    success "Updated managed AGENTS.md"
+  else
+    warn "Found existing unmanaged AGENTS.md"
+    read -r -p "Overwrite vault AGENTS.md with Crew dispatcher? [o/s]: " AGENTS_ANSWER || true
+    if [[ "${AGENTS_ANSWER:-s}" =~ ^[Oo]$ ]]; then
+      cp "$TMP_AGENTS" "$VAULT_DIR/AGENTS.md"
+      success "Overwrote AGENTS.md"
+    else
+      cp "$TMP_AGENTS" "$VAULT_DIR/AGENTS.crew.md"
+      warn "Wrote AGENTS.crew.md instead"
+    fi
+  fi
+else
+  cp "$TMP_AGENTS" "$VAULT_DIR/AGENTS.md"
+  success "Installed AGENTS.md"
+fi
+rm -f "$TMP_AGENTS"
+
+# Optional MCP file
+read -r -p "Set up Gmail + Google Calendar MCP (.mcp.json)? [y/N]: " MCP_ANSWER || true
+if [[ "${MCP_ANSWER:-n}" =~ ^[Yy]$ ]]; then
+  if [[ -f "$VAULT_DIR/.mcp.json" ]]; then
+    warn ".mcp.json already exists, not overwriting"
+  else
+    cp "$REPO_DIR/.mcp.json" "$VAULT_DIR/.mcp.json"
+    success "Created .mcp.json"
+  fi
+fi
+
+echo
+echo "Codex setup complete."
+echo "Installed to: $VAULT_DIR/.codex"
+echo "Next steps:"
+echo "1) Open Codex CLI inside the vault folder"
+echo "2) Ensure AGENTS.md (or AGENTS.crew.md) is active for this vault"
+echo "3) Start with: Initialize my vault"

--- a/scripts/launchme-codex.sh
+++ b/scripts/launchme-codex.sh
@@ -54,6 +54,8 @@ if [[ -f "$OLD_MANIFEST" ]]; then
     deprecated_name="${old_name%.md}-DEPRECATED.md"
     [[ -f "$VAULT_DIR/.codex/deprecated/$deprecated_name" ]] && continue
     mv "$dst" "$VAULT_DIR/.codex/deprecated/$deprecated_name"
+    { echo "########"; echo "DEPRECATED DO NOT USE"; echo "########"; echo ""; cat "$VAULT_DIR/.codex/deprecated/$deprecated_name"; } > "$VAULT_DIR/.codex/deprecated/$deprecated_name.tmp"
+    mv "$VAULT_DIR/.codex/deprecated/$deprecated_name.tmp" "$VAULT_DIR/.codex/deprecated/$deprecated_name"
     warn "Deprecated stale Codex agent: $old_name"
   done < "$OLD_MANIFEST"
 fi

--- a/scripts/lib/CodexTransform.ps1
+++ b/scripts/lib/CodexTransform.ps1
@@ -1,0 +1,40 @@
+Set-StrictMode -Version Latest
+
+function Convert-ToCodexContent {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Content
+  )
+
+  $content = $Content
+  $content = $content -replace '\.claude/', '.codex/'
+  $content = $content -replace '\.claude\b', '.codex'
+  $content = $content -replace '\bCLAUDE\.md\b', 'AGENTS.md'
+  $content = $content -replace '`Skill` tool', 'skills system'
+  $content = $content -replace '`Agent` tool', 'spawn_agent tool'
+  $content = $content -replace 'Skill tool', 'skills system'
+  $content = $content -replace 'Agent tool', 'spawn_agent tool'
+  $content = $content -replace 'AskUserQuestion', 'request_user_input'
+  $content = $content -replace 'scripts/launchme\.sh', 'scripts/launchme-codex.sh'
+  $content = $content -replace 'scripts/updateme\.sh', 'scripts/updateme-codex.sh'
+  $content = $content -replace '`launchme\.sh`', '`launchme-codex.sh`'
+  $content = $content -replace '`updateme\.sh`', '`updateme-codex.sh`'
+  $content = $content -replace '\blaunchme\.sh\b', 'launchme-codex.sh'
+  $content = $content -replace '\bupdateme\.sh\b', 'updateme-codex.sh'
+  $content = $content -replace 'Claude Code', 'Codex CLI'
+  return $content
+}
+
+function Convert-ToCodexFile {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$SourcePath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$DestinationPath
+  )
+
+  $raw = Get-Content -Raw -LiteralPath $SourcePath
+  $transformed = Convert-ToCodexContent -Content $raw
+  Set-Content -LiteralPath $DestinationPath -Value $transformed -NoNewline
+}

--- a/scripts/lib/codex-transform.sh
+++ b/scripts/lib/codex-transform.sh
@@ -7,10 +7,11 @@ render_for_codex_file() {
   local src="$1"
   local dst="$2"
 
+  # NOTE: avoid \b word-boundary assertions — they are a GNU extension
+  # and silently fail on macOS BSD sed, causing Claude tokens to leak.
   sed -E \
     -e 's/\.claude\//.codex\//g' \
-    -e 's/\.claude\b/.codex/g' \
-    -e 's/\bCLAUDE\.md\b/AGENTS.md/g' \
+    -e 's/CLAUDE\.md/AGENTS.md/g' \
     -e 's/`Skill` tool/skills system/g' \
     -e 's/`Agent` tool/spawn_agent tool/g' \
     -e 's/Skill tool/skills system/g' \
@@ -20,8 +21,8 @@ render_for_codex_file() {
     -e 's/scripts\/updateme\.sh/scripts\/updateme-codex.sh/g' \
     -e 's/`launchme\.sh`/`launchme-codex.sh`/g' \
     -e 's/`updateme\.sh`/`updateme-codex.sh`/g' \
-    -e 's/\blaunchme\.sh\b/launchme-codex.sh/g' \
-    -e 's/\bupdateme\.sh\b/updateme-codex.sh/g' \
+    -e 's/launchme\.sh/launchme-codex.sh/g' \
+    -e 's/updateme\.sh/updateme-codex.sh/g' \
     -e 's/Claude Code/Codex CLI/g' \
     "$src" > "$dst"
 }

--- a/scripts/lib/codex-transform.sh
+++ b/scripts/lib/codex-transform.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Shared text transformation helpers for Codex runtime artifacts.
+
+set -euo pipefail
+
+render_for_codex_file() {
+  local src="$1"
+  local dst="$2"
+
+  sed -E \
+    -e 's/\.claude\//.codex\//g' \
+    -e 's/\.claude\b/.codex/g' \
+    -e 's/\bCLAUDE\.md\b/AGENTS.md/g' \
+    -e 's/`Skill` tool/skills system/g' \
+    -e 's/`Agent` tool/spawn_agent tool/g' \
+    -e 's/Skill tool/skills system/g' \
+    -e 's/Agent tool/spawn_agent tool/g' \
+    -e 's/AskUserQuestion/request_user_input/g' \
+    -e 's/scripts\/launchme\.sh/scripts\/launchme-codex.sh/g' \
+    -e 's/scripts\/updateme\.sh/scripts\/updateme-codex.sh/g' \
+    -e 's/`launchme\.sh`/`launchme-codex.sh`/g' \
+    -e 's/`updateme\.sh`/`updateme-codex.sh`/g' \
+    -e 's/\blaunchme\.sh\b/launchme-codex.sh/g' \
+    -e 's/\bupdateme\.sh\b/updateme-codex.sh/g' \
+    -e 's/Claude Code/Codex CLI/g' \
+    "$src" > "$dst"
+}

--- a/scripts/tests/compatibility-gate.ps1
+++ b/scripts/tests/compatibility-gate.ps1
@@ -1,0 +1,55 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoDir = (Resolve-Path (Join-Path $PSScriptRoot '../..')).Path
+$tmpRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("crew-compat-" + [guid]::NewGuid().ToString('N'))
+$vaultDir = Join-Path $tmpRoot 'vault'
+$workDir = Join-Path $vaultDir 'My-Brain-Is-Full-Crew'
+
+function Assert-True {
+  param([bool]$Condition, [string]$Message)
+  if (-not $Condition) { throw $Message }
+}
+
+try {
+  New-Item -ItemType Directory -Force -Path $vaultDir | Out-Null
+  Copy-Item -LiteralPath $repoDir -Destination $workDir -Recurse
+
+  New-Item -ItemType Directory -Force -Path (Join-Path $vaultDir '.claude/agents') | Out-Null
+  Set-Content -LiteralPath (Join-Path $vaultDir '.claude/agents/sentinel.md') -Value 'do-not-touch'
+  New-Item -ItemType Directory -Force -Path (Join-Path $vaultDir '.claude/references') | Out-Null
+  Set-Content -LiteralPath (Join-Path $vaultDir 'CLAUDE.md') -Value 'do-not-touch'
+
+  Push-Location $workDir
+
+  "y`nn" | powershell -NoProfile -ExecutionPolicy Bypass -File scripts/launchme-codex.ps1 | Out-Null
+  Assert-True (Test-Path -LiteralPath (Join-Path $vaultDir '.codex/agents')) '.codex/agents missing'
+  Assert-True (Test-Path -LiteralPath (Join-Path $vaultDir '.codex/skills')) '.codex/skills missing'
+  Assert-True (Test-Path -LiteralPath (Join-Path $vaultDir '.codex/references')) '.codex/references missing'
+  Assert-True (Test-Path -LiteralPath (Join-Path $vaultDir 'AGENTS.md')) 'AGENTS.md missing'
+
+  $codexAgents = (Get-ChildItem -LiteralPath (Join-Path $vaultDir '.codex/agents') -Filter *.md -File).Count
+  $codexSkills = (Get-ChildItem -LiteralPath (Join-Path $vaultDir '.codex/skills') -Directory).Count
+  Assert-True ($codexAgents -eq 8) "Expected 8 Codex agents, got $codexAgents"
+  Assert-True ($codexSkills -eq 13) "Expected 13 Codex skills, got $codexSkills"
+
+  $bad = Get-ChildItem -LiteralPath (Join-Path $vaultDir '.codex') -Recurse -File -Include *.md,*.sh,*.ps1 |
+    Select-String -Pattern '\.claude/|\bCLAUDE\.md\b|AskUserQuestion|Skill tool|Agent tool' -SimpleMatch:$false -CaseSensitive
+  Assert-True (($bad | Measure-Object).Count -eq 0) 'Found unresolved Claude-specific tokens in .codex runtime'
+
+  "c" | powershell -NoProfile -ExecutionPolicy Bypass -File scripts/updateme-codex.ps1 | Out-Null
+  Assert-True (Test-Path -LiteralPath (Join-Path $vaultDir '.codex/agents')) '.codex/agents missing after Codex update'
+
+  $sentinel = Get-Content -Raw -LiteralPath (Join-Path $vaultDir '.claude/agents/sentinel.md')
+  Assert-True ($sentinel.Trim() -eq 'do-not-touch') 'Codex flow modified existing Claude sentinel file'
+  $claudeRoot = Get-Content -Raw -LiteralPath (Join-Path $vaultDir 'CLAUDE.md')
+  Assert-True ($claudeRoot.Trim() -eq 'do-not-touch') 'Codex flow modified existing CLAUDE.md'
+
+  Write-Host 'compatibility-gate.ps1 passed'
+}
+finally {
+  Pop-Location -ErrorAction SilentlyContinue
+  if (Test-Path -LiteralPath $tmpRoot) {
+    Remove-Item -LiteralPath $tmpRoot -Recurse -Force
+  }
+}

--- a/scripts/tests/compatibility-gate.sh
+++ b/scripts/tests/compatibility-gate.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+VAULT_DIR="$TMP_ROOT/vault"
+WORK_DIR="$VAULT_DIR/My-Brain-Is-Full-Crew"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$VAULT_DIR"
+cp -R "$REPO_DIR" "$WORK_DIR"
+
+pushd "$WORK_DIR" >/dev/null
+
+# Claude installer smoke test
+printf 'y\nn\n' | bash scripts/launchme.sh >/tmp/crew-claude-install.log
+[[ -d "$VAULT_DIR/.claude/agents" ]]
+[[ -d "$VAULT_DIR/.claude/skills" ]]
+[[ -f "$VAULT_DIR/CLAUDE.md" ]]
+[[ "$(find "$VAULT_DIR/.claude/agents" -maxdepth 1 -name '*.md' | wc -l | tr -d ' ')" == "8" ]]
+[[ "$(find "$VAULT_DIR/.claude/skills" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')" == "13" ]]
+
+# Codex installer smoke test
+printf 'y\nn\n' | bash scripts/launchme-codex.sh >/tmp/crew-codex-install.log
+[[ -d "$VAULT_DIR/.codex/agents" ]]
+[[ -d "$VAULT_DIR/.codex/skills" ]]
+[[ -d "$VAULT_DIR/.codex/references" ]]
+[[ -f "$VAULT_DIR/AGENTS.md" ]]
+[[ "$(find "$VAULT_DIR/.codex/agents" -maxdepth 1 -name '*.md' | wc -l | tr -d ' ')" == "8" ]]
+[[ "$(find "$VAULT_DIR/.codex/skills" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')" == "13" ]]
+
+# Token rewrite guard for Codex runtime
+if grep -RInE "\\.claude/|\\bCLAUDE\\.md\\b|AskUserQuestion|Skill tool|Agent tool" "$VAULT_DIR/.codex"; then
+  echo "Found unresolved Claude-specific tokens in .codex runtime" >&2
+  exit 1
+fi
+
+# Updater smoke tests
+printf 'c\n' | bash scripts/updateme.sh >/tmp/crew-claude-update.log
+printf 'c\n' | bash scripts/updateme-codex.sh >/tmp/crew-codex-update.log
+
+[[ -d "$VAULT_DIR/.claude/agents" ]]
+[[ -d "$VAULT_DIR/.codex/agents" ]]
+
+echo "compatibility-gate.sh passed"
+popd >/dev/null
+

--- a/scripts/tests/compatibility-gate.sh
+++ b/scripts/tests/compatibility-gate.sh
@@ -39,12 +39,19 @@ if grep -RInE "\\.claude/|\\bCLAUDE\\.md\\b|AskUserQuestion|Skill tool|Agent too
   exit 1
 fi
 
+# Cross-contamination guard: Codex installer must not touch Claude runtime
+CLAUDE_MD_BEFORE="$(cat "$VAULT_DIR/CLAUDE.md")"
+
 # Updater smoke tests
 printf 'c\n' | bash scripts/updateme.sh >/tmp/crew-claude-update.log
 printf 'c\n' | bash scripts/updateme-codex.sh >/tmp/crew-codex-update.log
 
 [[ -d "$VAULT_DIR/.claude/agents" ]]
 [[ -d "$VAULT_DIR/.codex/agents" ]]
+
+# Verify Claude files were not modified by Codex operations
+CLAUDE_MD_AFTER="$(cat "$VAULT_DIR/CLAUDE.md")"
+[[ "$CLAUDE_MD_BEFORE" == "$CLAUDE_MD_AFTER" ]] || { echo "Codex updater modified CLAUDE.md" >&2; exit 1; }
 
 echo "compatibility-gate.sh passed"
 popd >/dev/null

--- a/scripts/updateme-codex.ps1
+++ b/scripts/updateme-codex.ps1
@@ -1,0 +1,221 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. "$PSScriptRoot/lib/CodexTransform.ps1"
+
+$repoDir = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$vaultDir = (Resolve-Path (Join-Path $repoDir '..')).Path
+$codexDir = Join-Path $vaultDir '.codex'
+$agentsDir = Join-Path $codexDir 'agents'
+$refsDir = Join-Path $codexDir 'references'
+$skillsDir = Join-Path $codexDir 'skills'
+
+function Info([string]$msg) { Write-Host "[INFO] $msg" }
+function Ok([string]$msg) { Write-Host "[OK]   $msg" }
+function Warn([string]$msg) { Write-Host "[WARN] $msg" }
+
+if (-not (Test-Path -LiteralPath $agentsDir)) { throw "No .codex/agents found in $vaultDir. Run launchme-codex.ps1 first." }
+
+$updateAnswer = Read-Host 'Update Codex core files in this vault? [c/q]'
+if ($updateAnswer -notmatch '^[Cc]$') {
+  Info 'Update cancelled'
+  exit 0
+}
+
+$manifest = Join-Path $agentsDir '.core-manifest'
+if (Test-Path -LiteralPath $manifest) {
+  foreach ($oldName in Get-Content -LiteralPath $manifest) {
+    if ([string]::IsNullOrWhiteSpace($oldName)) { continue }
+    if (Test-Path -LiteralPath (Join-Path $repoDir "agents/$oldName")) { continue }
+    $dst = Join-Path $agentsDir $oldName
+    if (-not (Test-Path -LiteralPath $dst)) { continue }
+    $depDir = Join-Path $codexDir 'deprecated'
+    New-Item -ItemType Directory -Force -Path $depDir | Out-Null
+    $depName = [IO.Path]::GetFileNameWithoutExtension($oldName) + '-DEPRECATED.md'
+    $depPath = Join-Path $depDir $depName
+    if (Test-Path -LiteralPath $depPath) { continue }
+    Move-Item -LiteralPath $dst -Destination $depPath
+    Warn "Deprecated removed core agent: $oldName"
+  }
+}
+
+$agentCount = 0
+$manifestLines = New-Object System.Collections.Generic.List[string]
+Get-ChildItem -LiteralPath (Join-Path $repoDir 'agents') -Filter *.md -File | ForEach-Object {
+  $dst = Join-Path $agentsDir $_.Name
+  $tmp = "$dst.tmp"
+  Convert-ToCodexFile -SourcePath $_.FullName -DestinationPath $tmp
+  if ((-not (Test-Path -LiteralPath $dst)) -or ((Get-FileHash -LiteralPath $tmp).Hash -ne (Get-FileHash -LiteralPath $dst).Hash)) {
+    Move-Item -LiteralPath $tmp -Destination $dst -Force
+    Info "Updated agent: $($_.Name)"
+    $agentCount++
+  } else {
+    Remove-Item -LiteralPath $tmp -Force
+  }
+  $manifestLines.Add($_.Name)
+}
+Set-Content -LiteralPath $manifest -Value $manifestLines
+
+$refManifest = Join-Path $refsDir '.core-manifest'
+if (Test-Path -LiteralPath $refManifest) {
+  foreach ($oldRef in Get-Content -LiteralPath $refManifest) {
+    if ([string]::IsNullOrWhiteSpace($oldRef)) { continue }
+    if (Test-Path -LiteralPath (Join-Path $repoDir "references/$oldRef")) { continue }
+    $dst = Join-Path $refsDir $oldRef
+    if (-not (Test-Path -LiteralPath $dst)) { continue }
+    $depDir = Join-Path $codexDir 'deprecated'
+    New-Item -ItemType Directory -Force -Path $depDir | Out-Null
+    $depName = [IO.Path]::GetFileNameWithoutExtension($oldRef) + '-DEPRECATED.md'
+    $depPath = Join-Path $depDir $depName
+    if (Test-Path -LiteralPath $depPath) { continue }
+    Move-Item -LiteralPath $dst -Destination $depPath
+    Warn "Deprecated removed core reference: $oldRef"
+  }
+}
+
+$userMutable = @('agents-registry.md', 'agents.md')
+$refCount = 0
+$refLines = New-Object System.Collections.Generic.List[string]
+Get-ChildItem -LiteralPath (Join-Path $repoDir 'references') -Filter *.md -File | ForEach-Object {
+  $name = $_.Name
+  $dst = Join-Path $refsDir $name
+  $refLines.Add($name)
+
+  # For mutable files, merge upstream core changes while preserving custom content.
+  if ((Test-Path -LiteralPath $dst) -and $userMutable.Contains($name)) {
+    $customSection = @()
+    $existingLines = Get-Content -LiteralPath $dst
+    for ($i = 0; $i -lt $existingLines.Count; $i++) {
+      if ($existingLines[$i] -match '^## Custom Agents') {
+        $customSection = $existingLines[$i..($existingLines.Count - 1)]
+        break
+      }
+    }
+
+    $customRows = New-Object System.Collections.Generic.List[string]
+    if ($name -eq 'agents-registry.md') {
+      $coreNames = @('architect', 'scribe', 'sorter', 'seeker', 'connector', 'librarian', 'transcriber', 'postman')
+      foreach ($line in $existingLines) {
+        if ($line -notmatch '^\|') { continue }
+        if ($line -match '^\|[ ]*Name[ ]*\|') { continue }
+        if ($line -match '^\|[- :|]+\|?$') { continue }
+        $parts = $line.Split('|')
+        if ($parts.Length -lt 3) { continue }
+        $agentName = $parts[1].Trim()
+        if ([string]::IsNullOrWhiteSpace($agentName)) { continue }
+        if ($coreNames -contains $agentName) { continue }
+        $customRows.Add($line)
+      }
+    }
+
+    $tmp = "$dst.tmp"
+    Convert-ToCodexFile -SourcePath $_.FullName -DestinationPath $tmp
+
+    if (($name -eq 'agents-registry.md') -and ($customRows.Count -gt 0)) {
+      $tmpLines = Get-Content -LiteralPath $tmp
+      $lastTableIndex = -1
+      for ($i = 0; $i -lt $tmpLines.Count; $i++) {
+        if ($tmpLines[$i] -match '^\|') { $lastTableIndex = $i }
+      }
+      if ($lastTableIndex -ge 0) {
+        $merged = New-Object System.Collections.Generic.List[string]
+        if ($lastTableIndex -ge 0) {
+          foreach ($line in $tmpLines[0..$lastTableIndex]) { $merged.Add($line) | Out-Null }
+        }
+        foreach ($row in $customRows) { $merged.Add($row) | Out-Null }
+        if ($lastTableIndex + 1 -lt $tmpLines.Count) {
+          foreach ($line in $tmpLines[($lastTableIndex + 1)..($tmpLines.Count - 1)]) { $merged.Add($line) | Out-Null }
+        }
+        Set-Content -LiteralPath $tmp -Value $merged
+      }
+    }
+
+    if ($customSection.Count -gt 0) {
+      $tmpLines = Get-Content -LiteralPath $tmp
+      $customHeaderIndex = -1
+      for ($i = 0; $i -lt $tmpLines.Count; $i++) {
+        if ($tmpLines[$i] -match '^## Custom Agents') {
+          $customHeaderIndex = $i
+          break
+        }
+      }
+      if ($customHeaderIndex -ge 0) {
+        $merged = New-Object System.Collections.Generic.List[string]
+        if ($customHeaderIndex -gt 0) {
+          foreach ($line in $tmpLines[0..($customHeaderIndex - 1)]) { $merged.Add($line) | Out-Null }
+        }
+        foreach ($line in $customSection) { $merged.Add($line) | Out-Null }
+        Set-Content -LiteralPath $tmp -Value $merged
+      }
+    }
+
+    if ((Get-FileHash -LiteralPath $tmp).Hash -ne (Get-FileHash -LiteralPath $dst).Hash) {
+      Move-Item -LiteralPath $tmp -Destination $dst -Force
+      Info "Updated reference: $name (preserved custom content)"
+      $refCount++
+    } else {
+      Remove-Item -LiteralPath $tmp -Force
+    }
+    return
+  }
+
+  $tmp = "$dst.tmp"
+  Convert-ToCodexFile -SourcePath $_.FullName -DestinationPath $tmp
+  if ((-not (Test-Path -LiteralPath $dst)) -or ((Get-FileHash -LiteralPath $tmp).Hash -ne (Get-FileHash -LiteralPath $dst).Hash)) {
+    Move-Item -LiteralPath $tmp -Destination $dst -Force
+    Info "Updated reference: $name"
+    $refCount++
+  } else {
+    Remove-Item -LiteralPath $tmp -Force
+  }
+}
+Set-Content -LiteralPath $refManifest -Value $refLines
+
+$skillCount = 0
+Get-ChildItem -LiteralPath (Join-Path $repoDir 'skills') -Directory | ForEach-Object {
+  $skillSrc = Join-Path $_.FullName 'SKILL.md'
+  if (-not (Test-Path -LiteralPath $skillSrc)) { return }
+  $skillDstDir = Join-Path $skillsDir $_.Name
+  New-Item -ItemType Directory -Force -Path $skillDstDir | Out-Null
+  $dst = Join-Path $skillDstDir 'SKILL.md'
+  $tmp = "$dst.tmp"
+  Convert-ToCodexFile -SourcePath $skillSrc -DestinationPath $tmp
+  if ((-not (Test-Path -LiteralPath $dst)) -or ((Get-FileHash -LiteralPath $tmp).Hash -ne (Get-FileHash -LiteralPath $dst).Hash)) {
+    Move-Item -LiteralPath $tmp -Destination $dst -Force
+    Info "Updated skill: $($_.Name)"
+    $skillCount++
+  } else {
+    Remove-Item -LiteralPath $tmp -Force
+  }
+}
+
+$managedHeader = '<!-- managed-by: my-brain-is-full-crew -->'
+$generatedAgents = Join-Path $codexDir 'AGENTS.generated.md'
+$baseAgents = Get-Content -Raw -LiteralPath (Join-Path $repoDir 'AGENTS.md')
+Set-Content -LiteralPath $generatedAgents -Value ($managedHeader + [Environment]::NewLine + $baseAgents)
+
+$vaultAgents = Join-Path $vaultDir 'AGENTS.md'
+if (Test-Path -LiteralPath $vaultAgents) {
+  $existingAgents = Get-Content -Raw -LiteralPath $vaultAgents
+  if ($existingAgents.Contains($managedHeader)) {
+    Copy-Item -LiteralPath $generatedAgents -Destination $vaultAgents -Force
+    Info 'Updated managed AGENTS.md'
+  } else {
+    Warn 'Vault AGENTS.md is unmanaged'
+    $answer = Read-Host 'Overwrite unmanaged AGENTS.md? [o/s]'
+    if ($answer -match '^[Oo]$') {
+      Copy-Item -LiteralPath $generatedAgents -Destination $vaultAgents -Force
+      Info 'Overwrote AGENTS.md'
+    } else {
+      Copy-Item -LiteralPath $generatedAgents -Destination (Join-Path $vaultDir 'AGENTS.crew.md') -Force
+      Warn 'Wrote AGENTS.crew.md instead'
+    }
+  }
+} else {
+  Copy-Item -LiteralPath $generatedAgents -Destination $vaultAgents -Force
+  Info 'Installed AGENTS.md'
+}
+Remove-Item -LiteralPath $generatedAgents -Force
+
+Ok 'Codex update complete'
+Write-Host "Updated: $agentCount agent(s), $skillCount skill(s), $refCount reference(s)"

--- a/scripts/updateme-codex.ps1
+++ b/scripts/updateme-codex.ps1
@@ -35,6 +35,8 @@ if (Test-Path -LiteralPath $manifest) {
     $depPath = Join-Path $depDir $depName
     if (Test-Path -LiteralPath $depPath) { continue }
     Move-Item -LiteralPath $dst -Destination $depPath
+    $depContent = Get-Content -Raw -LiteralPath $depPath
+    Set-Content -LiteralPath $depPath -Value ("########`nDEPRECATED DO NOT USE`n########`n`n" + $depContent)
     Warn "Deprecated removed core agent: $oldName"
   }
 }
@@ -69,6 +71,8 @@ if (Test-Path -LiteralPath $refManifest) {
     $depPath = Join-Path $depDir $depName
     if (Test-Path -LiteralPath $depPath) { continue }
     Move-Item -LiteralPath $dst -Destination $depPath
+    $depContent = Get-Content -Raw -LiteralPath $depPath
+    Set-Content -LiteralPath $depPath -Value ("########`nDEPRECATED DO NOT USE`n########`n`n" + $depContent)
     Warn "Deprecated removed core reference: $oldRef"
   }
 }

--- a/scripts/updateme-codex.sh
+++ b/scripts/updateme-codex.sh
@@ -34,6 +34,8 @@ if [[ -f "$MANIFEST" ]]; then
     deprecated_name="${old_name%.md}-DEPRECATED.md"
     [[ -f "$VAULT_DIR/.codex/deprecated/$deprecated_name" ]] && continue
     mv "$dst" "$VAULT_DIR/.codex/deprecated/$deprecated_name"
+    { echo "########"; echo "DEPRECATED DO NOT USE"; echo "########"; echo ""; cat "$VAULT_DIR/.codex/deprecated/$deprecated_name"; } > "$VAULT_DIR/.codex/deprecated/$deprecated_name.tmp"
+    mv "$VAULT_DIR/.codex/deprecated/$deprecated_name.tmp" "$VAULT_DIR/.codex/deprecated/$deprecated_name"
     warn "Deprecated removed core agent: $old_name"
   done < "$MANIFEST"
 fi
@@ -68,6 +70,8 @@ if [[ -f "$REF_MANIFEST" ]]; then
     deprecated_name="${old_ref%.md}-DEPRECATED.md"
     [[ -f "$VAULT_DIR/.codex/deprecated/$deprecated_name" ]] && continue
     mv "$dst" "$VAULT_DIR/.codex/deprecated/$deprecated_name"
+    { echo "########"; echo "DEPRECATED DO NOT USE"; echo "########"; echo ""; cat "$VAULT_DIR/.codex/deprecated/$deprecated_name"; } > "$VAULT_DIR/.codex/deprecated/$deprecated_name.tmp"
+    mv "$VAULT_DIR/.codex/deprecated/$deprecated_name.tmp" "$VAULT_DIR/.codex/deprecated/$deprecated_name"
     warn "Deprecated removed core reference: $old_ref"
   done < "$REF_MANIFEST"
 fi

--- a/scripts/updateme-codex.sh
+++ b/scripts/updateme-codex.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# =============================================================================
+# My Brain Is Full - Crew :: Codex Updater
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+VAULT_DIR="$(cd "$REPO_DIR/.." && pwd)"
+
+# shellcheck source=/dev/null
+source "$REPO_DIR/scripts/lib/codex-transform.sh"
+
+info()    { echo "[INFO] $*"; }
+success() { echo "[OK]   $*"; }
+warn()    { echo "[WARN] $*"; }
+die()     { echo "[ERR]  $*" >&2; exit 1; }
+
+[[ -d "$VAULT_DIR/.codex/agents" ]] || die "No .codex/agents found in $VAULT_DIR. Run launchme-codex.sh first."
+
+read -r -p "Update Codex core files in this vault? [c/q]: " UPDATE_ANSWER || true
+[[ "${UPDATE_ANSWER:-q}" =~ ^[Cc]$ ]] || { info "Update cancelled"; exit 0; }
+
+# Deprecate removed core agents
+MANIFEST="$VAULT_DIR/.codex/agents/.core-manifest"
+if [[ -f "$MANIFEST" ]]; then
+  while IFS= read -r old_name; do
+    [[ -z "$old_name" ]] && continue
+    [[ -f "$REPO_DIR/agents/$old_name" ]] && continue
+    dst="$VAULT_DIR/.codex/agents/$old_name"
+    [[ -f "$dst" ]] || continue
+    mkdir -p "$VAULT_DIR/.codex/deprecated"
+    deprecated_name="${old_name%.md}-DEPRECATED.md"
+    [[ -f "$VAULT_DIR/.codex/deprecated/$deprecated_name" ]] && continue
+    mv "$dst" "$VAULT_DIR/.codex/deprecated/$deprecated_name"
+    warn "Deprecated removed core agent: $old_name"
+  done < "$MANIFEST"
+fi
+
+# Update agents
+AGENT_COUNT=0
+: > "$VAULT_DIR/.codex/agents/.core-manifest"
+for agent in "$REPO_DIR/agents/"*.md; do
+  name="$(basename "$agent")"
+  dst="$VAULT_DIR/.codex/agents/$name"
+  tmp="$dst.tmp"
+  render_for_codex_file "$agent" "$tmp"
+  if [[ ! -f "$dst" ]] || ! diff -q "$tmp" "$dst" >/dev/null 2>&1; then
+    mv "$tmp" "$dst"
+    info "Updated agent: $name"
+    AGENT_COUNT=$((AGENT_COUNT + 1))
+  else
+    rm -f "$tmp"
+  fi
+  echo "$name" >> "$VAULT_DIR/.codex/agents/.core-manifest"
+done
+
+# Deprecate removed core references
+REF_MANIFEST="$VAULT_DIR/.codex/references/.core-manifest"
+if [[ -f "$REF_MANIFEST" ]]; then
+  while IFS= read -r old_ref; do
+    [[ -z "$old_ref" ]] && continue
+    [[ -f "$REPO_DIR/references/$old_ref" ]] && continue
+    dst="$VAULT_DIR/.codex/references/$old_ref"
+    [[ -f "$dst" ]] || continue
+    mkdir -p "$VAULT_DIR/.codex/deprecated"
+    deprecated_name="${old_ref%.md}-DEPRECATED.md"
+    [[ -f "$VAULT_DIR/.codex/deprecated/$deprecated_name" ]] && continue
+    mv "$dst" "$VAULT_DIR/.codex/deprecated/$deprecated_name"
+    warn "Deprecated removed core reference: $old_ref"
+  done < "$REF_MANIFEST"
+fi
+
+# Update references
+USER_MUTABLE_REFS="agents-registry.md agents.md"
+REF_COUNT=0
+mkdir -p "$VAULT_DIR/.codex/references"
+: > "$VAULT_DIR/.codex/references/.core-manifest"
+for ref in "$REPO_DIR/references/"*.md; do
+  ref_name="$(basename "$ref")"
+  dst="$VAULT_DIR/.codex/references/$ref_name"
+  echo "$ref_name" >> "$VAULT_DIR/.codex/references/.core-manifest"
+
+  # For user-mutable files: merge upstream core changes while preserving custom content
+  if [[ " $USER_MUTABLE_REFS " == *" $ref_name "* ]] && [[ -f "$dst" ]]; then
+    custom_section=""
+    if grep -qn "^## Custom Agents" "$dst"; then
+      custom_line=$(grep -n "^## Custom Agents" "$dst" | head -1 | cut -d: -f1)
+      custom_section=$(tail -n +"$custom_line" "$dst")
+    fi
+
+    custom_table_rows=""
+    if [[ "$ref_name" == "agents-registry.md" ]]; then
+      CORE_NAMES="architect scribe sorter seeker connector librarian transcriber postman"
+      while IFS= read -r row; do
+        agent_name=$(echo "$row" | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/, "", $2); print $2}')
+        if [[ -n "$agent_name" ]] && ! echo "$CORE_NAMES" | grep -qw "$agent_name"; then
+          custom_table_rows="${custom_table_rows}${row}"$'\n'
+        fi
+      done < <(grep "^|" "$dst" | grep -v "^|[[:space:]]*Name[[:space:]]*|" | grep -v "^|[-[:space:]]*|")
+    fi
+
+    tmp="$dst.tmp"
+    render_for_codex_file "$ref" "$tmp"
+
+    if [[ -n "$custom_table_rows" && "$ref_name" == "agents-registry.md" ]]; then
+      last_table_line=$(grep -n "^|" "$tmp" | tail -1 | cut -d: -f1)
+      if [[ -n "$last_table_line" ]]; then
+        { head -n "$last_table_line" "$tmp"; printf "%s" "$custom_table_rows"; tail -n +"$((last_table_line + 1))" "$tmp"; } > "$tmp.merge"
+        mv "$tmp.merge" "$tmp"
+      fi
+    fi
+
+    if [[ -n "$custom_section" ]]; then
+      repo_custom_line=$(grep -n "^## Custom Agents" "$tmp" | head -1 | cut -d: -f1)
+      if [[ -n "$repo_custom_line" ]]; then
+        head -n "$((repo_custom_line - 1))" "$tmp" > "$tmp.merge"
+        printf '%s\n' "$custom_section" >> "$tmp.merge"
+        mv "$tmp.merge" "$tmp"
+      fi
+    fi
+
+    if ! diff -q "$tmp" "$dst" >/dev/null 2>&1; then
+      mv "$tmp" "$dst"
+      info "Updated reference: $ref_name (preserved custom content)"
+      REF_COUNT=$((REF_COUNT + 1))
+    else
+      rm -f "$tmp"
+    fi
+    continue
+  fi
+
+  tmp="$dst.tmp"
+  render_for_codex_file "$ref" "$tmp"
+  if [[ ! -f "$dst" ]] || ! diff -q "$tmp" "$dst" >/dev/null 2>&1; then
+    mv "$tmp" "$dst"
+    info "Updated reference: $ref_name"
+    REF_COUNT=$((REF_COUNT + 1))
+  else
+    rm -f "$tmp"
+  fi
+done
+
+# Update skills
+SKILL_COUNT=0
+if [[ -d "$REPO_DIR/skills" ]]; then
+  for skill_dir in "$REPO_DIR/skills/"*/; do
+    [[ -f "$skill_dir/SKILL.md" ]] || continue
+    skill_name="$(basename "$skill_dir")"
+    mkdir -p "$VAULT_DIR/.codex/skills/$skill_name"
+    dst="$VAULT_DIR/.codex/skills/$skill_name/SKILL.md"
+    tmp="$dst.tmp"
+    render_for_codex_file "$skill_dir/SKILL.md" "$tmp"
+    if [[ ! -f "$dst" ]] || ! diff -q "$tmp" "$dst" >/dev/null 2>&1; then
+      mv "$tmp" "$dst"
+      info "Updated skill: $skill_name"
+      SKILL_COUNT=$((SKILL_COUNT + 1))
+    else
+      rm -f "$tmp"
+    fi
+  done
+fi
+
+# Update AGENTS.md
+MANAGED_HEADER="<!-- managed-by: my-brain-is-full-crew -->"
+TMP_AGENTS="$VAULT_DIR/.codex/AGENTS.generated.md"
+printf '%s\n' "$MANAGED_HEADER" > "$TMP_AGENTS"
+cat "$REPO_DIR/AGENTS.md" >> "$TMP_AGENTS"
+
+if [[ -f "$VAULT_DIR/AGENTS.md" ]]; then
+  if grep -qF "$MANAGED_HEADER" "$VAULT_DIR/AGENTS.md"; then
+    cp "$TMP_AGENTS" "$VAULT_DIR/AGENTS.md"
+    info "Updated managed AGENTS.md"
+  else
+    warn "Vault AGENTS.md is unmanaged"
+    read -r -p "Overwrite unmanaged AGENTS.md? [o/s]: " AGENTS_ANSWER || true
+    if [[ "${AGENTS_ANSWER:-s}" =~ ^[Oo]$ ]]; then
+      cp "$TMP_AGENTS" "$VAULT_DIR/AGENTS.md"
+      info "Overwrote AGENTS.md"
+    else
+      cp "$TMP_AGENTS" "$VAULT_DIR/AGENTS.crew.md"
+      warn "Wrote AGENTS.crew.md instead"
+    fi
+  fi
+else
+  cp "$TMP_AGENTS" "$VAULT_DIR/AGENTS.md"
+  info "Installed AGENTS.md"
+fi
+rm -f "$TMP_AGENTS"
+
+success "Codex update complete"
+echo "Updated: $AGENT_COUNT agent(s), $SKILL_COUNT skill(s), $REF_COUNT reference(s)"


### PR DESCRIPTION
## Summary
- add Codex runtime installer/updater flows for bash and PowerShell (launchme-codex*, updateme-codex*)
- add Codex transform helpers and generated AGENTS.md dispatcher guide for Codex CLI
- add compatibility gate scripts + CI workflow, and update docs for dual Claude/Codex setup
- preserve mutable Codex references (agents-registry.md, agents.md) during updates by merging upstream core changes with user custom content

## Verification
- powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/compatibility-gate.ps1 (pass)
- reviewed codex installer command in AGENTS.md and updater merge logic in both scripts/updateme-codex.sh and scripts/updateme-codex.ps1
- attempted bash scripts/tests/compatibility-gate.sh in this Windows environment; blocked by local CRLF bash execution behavior ($'\\r': command not found), covered by Linux CI gate