### PR TITLE
Clarify the current Codex runtime contract

### DIFF
--- a/DISPATCHER.md
+++ b/DISPATCHER.md
@@ -158,13 +158,17 @@ Custom agents are created via the `/create-agent` skill and stored in `.platform
 
 ## Multi-agent routing
 
-The dispatcher is a **reactive multi-router**. After invoking an agent, analyze its output before responding to the user:
+The dispatcher is an **offload-first multi-router**. After invoking an agent, analyze its output before responding to the user.
 
-1. Did the agent create content that needs filing? → Consider **Sorter**
-2. Did the agent report missing structure? → Consider **Architect**
-3. Did the agent find notes that need linking? → Consider **Connector**
-4. Did the agent produce notes that need cleanup? → Consider **Librarian**
-5. Did the agent include a `### Suggested next agent` section? → Validate and consider it
+Default rule:
+- If the next step is obvious, low-risk, and clearly belongs to another active skill or agent, continue the chain instead of pushing the decision back to the user.
+- If the next step would be destructive, structurally significant, ambiguous, or depends on a user preference you do not have yet, stop and ask the user directly.
+
+1. Did the agent create content that clearly needs filing? → Continue to **Sorter** when the filing path is obvious
+2. Did the agent report missing structure? → Continue to **Architect** when the structural fix is clear and low-risk
+3. Did the agent find notes that need linking? → Continue to **Connector** when the linking pass is the obvious next step
+4. Did the agent produce notes that need cleanup? → Continue to **Librarian** when the cleanup is routine and bounded
+5. Did the agent include a `### Suggested next agent` section? → Treat it as orchestration input, validate it, and continue automatically when it is the obvious low-risk follow-up
 6. Did the agent include a `### Suggested new agent` section? → Ask the user if they want the **Architect** to create a custom agent for the detected need
 
 Consult `.platform/references/agents-registry.md` to validate suggestions and match output to agent capabilities.
@@ -185,6 +189,19 @@ Maintain a call chain for each user request:
 - **Max depth 3**: no more than 3 agents per user request
 - **On overflow**: return results to the user and suggest what they can do next (e.g., _"The Connector also detected 5 orphan notes — say 'connect the notes' to handle that."_)
 
+### Continue vs stop
+
+Continue automatically when:
+- the follow-up is a normal consequence of the completed step
+- the next agent has enough context to act without inventing user preferences
+- the next step is bounded and reversible
+
+Stop and ask the user when:
+- multiple reasonable next steps exist
+- the work would delete, archive, rename, or restructure in a way that may surprise the user
+- the suggested next step crosses into a migration-gated or unsupported capability
+- the agent output signals uncertainty or missing context
+
 ### Decision flow
 
 ```
@@ -197,7 +214,7 @@ USER MESSAGE → check SKILL routing table first
      READ OUTPUT → check agents-registry.md
            ↓
   Does output match another agent's capabilities?
-     YES + not in chain + depth < 3 → INVOKE next
+     YES + not in chain + depth < 3 + obvious/low-risk → INVOKE next
      NO or limit reached → RESPOND to user
 ```
 
@@ -208,6 +225,8 @@ USER MESSAGE → check SKILL routing table first
 Agents do NOT communicate directly with each other. The dispatcher orchestrates all agent calls.
 
 When an agent detects work for another agent (e.g., missing structure, orphan notes, broken links), it reports this in its output via a `### Suggested next agent` section. The dispatcher reads this and decides whether to chain the next agent.
+
+`### Suggested next agent` is primarily for dispatcher continuation, not for turning obvious follow-up work into user homework.
 
 See `.platform/references/agent-orchestration.md` for the full protocol and `.platform/references/agents-registry.md` for the agent registry.
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Key points:
 | 8 | **Postman** | Email & Calendar | Bridges email (Gmail or Hey.com) and Google Calendar with your vault: deadline radar, meeting prep |
 
 > **Agents + Skills = the full system.** Each agent handles quick, reactive tasks. For complex multi-step workflows (like onboarding, email triage, or vault audits), the dispatcher routes to one of **14 specialized skills** that run as guided conversations. See the [Skills](#skills) section below.
+>
+> **Codex CLI status:** the Codex runtime currently activates **7 agents** and **10 skills**. `Postman`, `/email-triage`, `/meeting-prep`, `/weekly-agenda`, and `/deadline-radar` remain migration-gated until external email/calendar parity lands.
 
 ---
 
@@ -314,7 +316,7 @@ The `/onboarding` skill starts a friendly guided conversation:
 
 1. **Who are you?** Name, language, role, what brought you here
 2. **What do you need?** Which agents to activate, which areas of life to manage
-3. **Integrations** Gmail and Google Calendar connections
+3. **Integrations** Gmail and Google Calendar connections on platforms where Postman is active; in Codex CLI these preferences are recorded for a future migration phase
 
 After onboarding, the Architect creates your entire vault folder structure, saves your profile, leaves you a welcome note, and you're ready to go.
 
@@ -325,7 +327,7 @@ After onboarding, the Architect creates your entire vault folder structure, save
 | *"Save this: meeting with Marco about the Q3 budget, he wants the report by Friday"* | **Scribe** agent captures it as a clean note with tasks, wikilinks, and deadline |
 | *"Triage my inbox"* | `/inbox-triage` skill files everything, updates MOCs, gives you a summary |
 | *"What did we decide about the pricing strategy?"* | **Seeker** agent searches your vault, synthesizes the answer with source citations |
-| *"Check my email"* | `/email-triage` skill scans Gmail, saves important emails, flags deadlines |
+| *"Check my email"* | On Claude Code, Gemini CLI, and OpenCode, `/email-triage` scans Gmail or Hey. In Codex CLI, the dispatcher explains that Postman workflows are migration-gated. |
 | *"Weekly review"* | `/vault-audit` skill runs a full vault audit: broken links, duplicates, health score |
 | *"Find connections for my latest note"* | **Connector** agent discovers hidden links to other notes in your vault |
 
@@ -337,7 +339,7 @@ The Crew is built in English but **responds in whatever language you write in**.
 
 ```
 "Salva questa nota veloce..."          → Scribe responds in Italian
-"Vérifie mon email..."                 → Postman responds in French
+"Vérifie mon email..."                 → Codex explains the current Postman migration gate in French
 "Was habe ich diese Woche geplant?"    → Seeker responds in German
 "Check my inbox"                       → Sorter responds in English
 ```
@@ -358,6 +360,8 @@ Capture a quick thought on a walk. Check your email from the couch. Search your 
 
 ## Agent coordination
 
+> **Codex note:** Postman-driven chains stay migration-gated in the current Codex runtime. The examples below describe the intended orchestration model once external integrations reach parity.
+
 Agents coordinate through a dispatcher-driven orchestration system. When an agent or skill finishes its task and detects work for another agent, it signals the dispatcher via a `### Suggested next agent` section in its output. The dispatcher reads this and automatically chains the next agent:
 
 - The `/transcribe` skill processes a meeting that introduces a new project -- the dispatcher chains the **Architect** to create the folder structure
@@ -371,7 +375,7 @@ No agent works in isolation. The crew is greater than the sum of its parts.
 
 ## Required integrations
 
-The **Postman** agent (and its related skills: `/email-triage`, `/meeting-prep`, `/weekly-agenda`, `/deadline-radar`) requires one of:
+The **Postman** agent (and its related skills: `/email-triage`, `/meeting-prep`, `/weekly-agenda`, `/deadline-radar`) requires one of the following on platforms where Postman is active today. In the current Codex CLI runtime, these workflows are intentionally migration-gated and the dispatcher should explain the gate instead of running them:
 - **Google Workspace CLI** (`gws`) — full read/write access to Gmail and Google Calendar: search, read, archive, delete, label, send emails; create/update/delete calendar events. See [`docs/gws-setup-guide.md`](docs/gws-setup-guide.md) for setup.
 - **Hey CLI** (`hey`) — for Hey.com accounts. Read/reply/compose emails, leverages Hey's pre-sorted mailboxes (Imbox, Feed, Paper Trail, Reply Later, Set Aside, Bubble Up). Calendar operations still use `gws`. See [Hey CLI](https://github.com/basecamp/hey-cli) for installation.
 - **MCP connectors** (read-only fallback) — `launchme.sh` sets up MCP servers automatically (format varies by platform). Limited to reading emails and calendar events, plus draft creation.
@@ -443,16 +447,16 @@ My-Brain-Is-Full-Crew/               ← cloned inside your vault
 │   ├── connector.md                   Knowledge graph & link analysis
 │   ├── librarian.md                   Vault health & maintenance
 │   ├── transcriber.md                 Audio & meeting transcription
-│   └── postman.md                     Email & calendar integration
+│   └── postman.md                     Email & calendar integration (migration-gated in current Codex runtime)
 ├── skills/                          The 14 specialized skills
 │   ├── onboarding/SKILL.md            Full vault setup conversation
 │   ├── create-agent/SKILL.md          Design a custom agent step by step
 │   ├── manage-agent/SKILL.md          Edit, remove, or list custom agents
 │   ├── defrag/SKILL.md                Weekly vault defragmentation
-│   ├── email-triage/SKILL.md          Scan and prioritize unread emails
-│   ├── meeting-prep/SKILL.md          Comprehensive meeting brief
-│   ├── weekly-agenda/SKILL.md         Day-by-day week overview
-│   ├── deadline-radar/SKILL.md        Unified deadline timeline
+│   ├── email-triage/SKILL.md          Scan and prioritize unread emails (migration-gated in current Codex runtime)
+│   ├── meeting-prep/SKILL.md          Comprehensive meeting brief (migration-gated in current Codex runtime)
+│   ├── weekly-agenda/SKILL.md         Day-by-day week overview (migration-gated in current Codex runtime)
+│   ├── deadline-radar/SKILL.md        Unified deadline timeline (migration-gated in current Codex runtime)
 │   ├── transcribe/SKILL.md            Process recordings into structured notes
 │   ├── vault-audit/SKILL.md           Full 7-phase vault audit
 │   ├── deep-clean/SKILL.md            Extended vault cleanup
@@ -504,11 +508,11 @@ Codex CLI uses a split layout instead of a single platform directory:
 ```
 your-vault/
 ├── .codex/
-│   ├── agents/               ← 8 core agents (.toml format)
+│   ├── agents/               ← 8 core agent files (7 active + 1 migration-gated Postman role)
 │   ├── references/           ← shared docs
 │   └── config.toml           ← MCP servers + profiles + sandbox policy
 ├── .agents/
-│   └── skills/               ← 14 specialized skills
+│   └── skills/               ← 14 skill definitions (10 active + 4 migration-gated Postman skills)
 ├── Meta/
 │   └── scripts/              ← orchestra scripts
 ├── AGENTS.md                 ← dispatcher (Codex reads this)

--- a/adapters/codex-cli/adapter.sh
+++ b/adapters/codex-cli/adapter.sh
@@ -29,6 +29,7 @@ rewrite_codex_paths() {
     s|\.platform/references/|.codex/references/|g;
     s|\.platform/skills/|.agents/skills/|g;
     s|\.platform/|.codex/|g;
+    s|\.mcp\.json|.codex/config.toml|g;
     s|DISPATCHER\.md|AGENTS.md|g;
   ' "$file"
 }
@@ -101,6 +102,11 @@ normalize_codex_routing_contract() {
     s/\binvoke the skill\b/follow the skill instructions directly in the root context/g;
     s/\binvoke the agent\b/spawn a bounded child agent from the root context/g;
     s/\bask the user\b/ask the user directly in chat and wait for the reply/g;
+    s/follow the skill instructions directly in the root context via the `Skill` tool/follow the skill instructions directly in the root context/g;
+    s/\(Skill tool\)/(root-context skill flow)/g;
+    s/\(Agent tool\)/(bounded child agent)/g;
+    s/YES \+ not in chain \+ depth < 3 → INVOKE next/YES + not already handled → the root context decides whether another bounded child task is still necessary/g;
+    s/- \*\*Max depth 3\*\*: no more than 3 agents per user request/- **Child depth: `agents.max_depth = 1`**: the root context may spawn one bounded child task, then decides the next step itself/g;
   ' "$file"
 }
 
@@ -151,6 +157,249 @@ HEADER
 # Copies the source DISPATCHER.md to dest_dir/AGENTS.md (Codex CLI's vault-root
 # dispatcher filename). Rewrites .platform/ and DISPATCHER.md to codex paths,
 # normalizes Codex routing semantics, and prepends the Codex routing header.
+# _cc_prune_dispatcher_appendix <file>
+# Removes the source-repo installation appendix from generated Codex AGENTS.md.
+# That appendix is platform-general source documentation and leaks stale runtime
+# details (.mcp.json, .md agents, .codex/skills) into the Codex dispatcher.
+_cc_prune_dispatcher_appendix() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+  perl -0pi -e 's/\n# Project Info\n.*\z/\n/s' "$file"
+}
+
+_cc_insert_after_frontmatter() {
+  local file="$1" marker="$2" section="$3"
+  [[ -f "$file" ]] || return 0
+  grep -qF "$marker" "$file" && return 0
+
+  local boundary
+  boundary="$(awk 'BEGIN { count = 0 } /^---$/ { count++; if (count == 2) { print NR; exit } }' "$file")"
+  local tmp; tmp="$(mktemp)"
+
+  if [[ -n "$boundary" ]]; then
+    sed -n "1,${boundary}p" "$file" > "$tmp"
+    printf '\n%s\n' "$section" >> "$tmp"
+    sed -n "$((boundary + 1)),\$p" "$file" >> "$tmp"
+  else
+    printf '%s\n\n' "$section" > "$tmp"
+    cat "$file" >> "$tmp"
+  fi
+
+  mv "$tmp" "$file"
+}
+
+_cc_replace_literal_line() {
+  local file="$1" old="$2" new="$3"
+  [[ -f "$file" ]] || return 0
+  grep -qF "$old" "$file" || return 0
+
+  local tmp; tmp="$(mktemp)"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" == "$old" ]]; then
+      printf '%s
+' "$new"
+    else
+      printf '%s
+' "$line"
+    fi
+  done < "$file" > "$tmp"
+  mv "$tmp" "$file"
+}
+
+_cc_override_agent_description_for_codex() {
+  local name="$1" description="$2"
+  case "$name" in
+    postman)
+      printf '%s' 'Migration-gated placeholder for future email and calendar parity in Codex. Do not route active Codex email or calendar requests here; explain the current migration gate instead.'
+      ;;
+    *)
+      printf '%s' "$description"
+      ;;
+  esac
+}
+
+_cc_apply_codex_postman_gate_dispatcher() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+
+  FILE="$file" python - <<'PY'
+from pathlib import Path
+import os
+import re
+
+path = Path(os.environ["FILE"])
+text = path.read_text()
+newline = "\n" if text.endswith("\n") else ""
+
+text = text.replace(
+    "Your crew consists of **14 skills** (in `.agents/skills/`) and **8 core agents** (in `.codex/agents/`). Your agent platform auto-loads both at session start.\n\nThe 8 core agents are:\n\n`architect`, `scribe`, `sorter`, `seeker`, `connector`, `librarian`, `transcriber`, `postman`\n\nCustom agents created by the Architect are also valid. Check `.codex/references/agents-registry.md` for the full list of active agents (core + custom).",
+    "Your crew consists of **14 skills** (in `.agents/skills/`) and **8 core agents** (in `.codex/agents/`). Your agent platform auto-loads both at session start.\n\nIn the current Codex runtime, **10 skills** and **7 core agents** are active. `postman`, `/email-triage`, `/meeting-prep`, `/weekly-agenda`, and `/deadline-radar` are migration-gated until external email/calendar parity lands.\n\nThe 8 core agents are:\n\n`architect`, `scribe`, `sorter`, `seeker`, `connector`, `librarian`, `transcriber`, `postman`\n\nCustom agents created by the Architect are also valid. Check `.codex/references/agents-registry.md` for the full list of active and migration-gated units.",
+)
+
+gate_block = """## Migration-Gated Units
+
+Before normal skill or agent routing, check whether the request targets one of these Codex migration-gated units:
+
+- `postman`
+- `/email-triage`
+- `/meeting-prep`
+- `/weekly-agenda`
+- `/deadline-radar`
+
+If yes, explain that external Gmail, Hey, and Google Calendar workflows are not enabled in the current Codex runtime yet. Do not dispatch into those runtime files.
+"""
+if "## Migration-Gated Units" not in text:
+    text = text.replace("## How to delegate", gate_block + "\n## How to delegate", 1)
+
+line_map = {
+    "| 5 | `/email-triage` |": '| 5 | `/email-triage` | Migration-gated in Codex. Reserved for future email triage parity. | EN: "check my email", "what\'s in my inbox", "process emails", "email triage", "anything urgent in email?", "save important emails" · IT: "controlla le email", "cosa c\'è nella mia inbox", "triage email", "processa le email", "email urgenti" · FR: "vérifier mes emails", "trier mes emails" · ES: "revisar mi correo", "triaje de emails" · DE: "E-Mails prüfen", "Posteingang sichten" · PT: "verificar meus emails", "triagem de emails" |',
+    "| 6 | `/meeting-prep` |": '| 6 | `/meeting-prep` | Migration-gated in Codex. Reserved for future meeting brief parity once email/calendar integrations land. | EN: "prepare for meeting", "meeting prep", "brief me for the meeting", "get ready for the call" · IT: "prepara la riunione", "brief per il meeting", "preparami per la call" · FR: "préparer la réunion", "brief pour le meeting" · ES: "preparar la reunión", "brief para la reunión" · DE: "Meeting vorbereiten", "Besprechung vorbereiten" · PT: "preparar a reunião", "brief para o meeting" |',
+    "| 7 | `/weekly-agenda` |": '| 7 | `/weekly-agenda` | Migration-gated in Codex. Reserved for future week aggregation from external integrations. | EN: "weekly agenda", "what\'s this week", "week overview", "plan my week" · IT: "agenda settimanale", "cosa c\'è questa settimana", "panoramica della settimana" · FR: "agenda de la semaine", "programme de la semaine" · ES: "agenda semanal", "qué hay esta semana" · DE: "Wochenagenda", "Wochenübersicht" · PT: "agenda semanal", "o que tem esta semana" |',
+    "| 8 | `/deadline-radar` |": '| 8 | `/deadline-radar` | Migration-gated in Codex. Reserved for future deadline aggregation from external integrations. | EN: "deadline radar", "what are my deadlines", "this week\'s deadlines", "upcoming deadlines" · IT: "scadenze", "radar scadenze", "le mie scadenze", "scadenze della settimana" · FR: "échéances", "radar des échéances" · ES: "fechas límite", "radar de plazos" · DE: "Fristen-Radar", "meine Fristen" · PT: "radar de prazos", "meus prazos" |',
+    "| 1 | **postman** |": "| 1 | **postman** | Migration-gated in Codex. Explain that external email/calendar integrations are not enabled yet. |",
+}
+
+lines = text.splitlines()
+for idx, line in enumerate(lines):
+    for prefix, replacement in line_map.items():
+        if line.startswith(prefix):
+            lines[idx] = replacement
+            break
+text = "\n".join(lines)
+
+text = re.sub(
+    r"\n## 1\. POSTMAN \(agent\)\n.*?\n---\n\n## 2\. TRANSCRIBER \(agent\)",
+    "\n## 1. POSTMAN (agent)\n\nThis agent is migration-gated in the current Codex runtime.\n\nIf the user asks for email or calendar work that would normally route here, explain that external Gmail, Hey, and Google Calendar workflows are not enabled yet in Codex. Do not dispatch into the Postman runtime files.\n\n---\n\n## 2. TRANSCRIBER (agent)",
+    text,
+    count=1,
+    flags=re.S,
+)
+
+path.write_text(text + newline)
+PY
+}
+
+_cc_apply_codex_postman_gate_registry() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+
+  FILE="$file" python - <<'PY'
+from pathlib import Path
+import os
+
+path = Path(os.environ["FILE"])
+text = path.read_text()
+newline = "\n" if text.endswith("\n") else ""
+
+lines = text.splitlines()
+for idx, line in enumerate(lines):
+    if line.startswith("| postman |"):
+        lines[idx] = "| postman | Email & Calendar Intelligence | Reserved for future Codex parity. External email/calendar integrations are currently migration-gated and must not be dispatched from the active runtime. | Email triage, calendar queries, deadline tracking, meeting prep, VIP filtering | For now, explain that external integrations are not yet enabled in the Codex runtime | migration-gated |"
+    elif line == "- **disabled**: Agent is temporarily disabled — the dispatcher will skip it":
+        if idx + 1 >= len(lines) or "migration-gated" not in lines[idx + 1]:
+            lines.insert(idx + 1, "- **migration-gated**: Agent or skill is intentionally excluded from active Codex dispatch until its external/runtime dependencies reach parity")
+    elif line.startswith('| `/email-triage` | postman |'):
+        lines[idx] = '| `/email-triage` | postman | "check my email", "what\'s in my inbox", "process emails", "email triage", "anything urgent in email?" | Reserved for future Codex parity; current runtime must explain that email integrations are migration-gated | migration-gated |'
+    elif line.startswith('| `/meeting-prep` | postman |'):
+        lines[idx] = '| `/meeting-prep` | postman | "prepare for meeting", "meeting prep", "brief me for the meeting", "get ready for the call" | Reserved for future Codex parity; current runtime must explain that meeting email/calendar enrichment is migration-gated | migration-gated |'
+    elif line.startswith('| `/weekly-agenda` | postman |'):
+        lines[idx] = '| `/weekly-agenda` | postman | "weekly agenda", "what\'s this week", "week overview", "plan my week" | Reserved for future Codex parity; current runtime must explain that external week aggregation is migration-gated | migration-gated |'
+    elif line.startswith('| `/deadline-radar` | postman |'):
+        lines[idx] = '| `/deadline-radar` | postman | "deadline radar", "what are my deadlines", "this week\'s deadlines", "upcoming deadlines" | Reserved for future Codex parity; current runtime must explain that external deadline aggregation is migration-gated | migration-gated |'
+
+path.write_text("\n".join(lines) + newline)
+PY
+}
+
+_cc_apply_codex_postman_gate_agents_reference() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+
+  FILE="$file" python - <<'PY'
+from pathlib import Path
+import os
+import re
+
+path = Path(os.environ["FILE"])
+text = path.read_text()
+newline = "\n" if text.endswith("\n") else ""
+
+text = text.replace("## The Eight Agents", "## Core Agents")
+text = re.sub(
+    r"### 8\. Postman\n\n\*\*Role\*\*: Email & Calendar Intelligence\n\*\*Agent file\*\*: `postman\.md`\n\*\*Requires\*\*:.*?\n\*\*Contact when\*\*: Important information may have arrived by email\. Meeting notes should be cross-referenced with calendar events\. An event needs to be created from a note\.\n",
+    "### 8. Postman\n\n**Role**: Email & Calendar Intelligence\n**Agent file**: `postman.md`\n**Codex runtime status**: migration-gated\n**Responsibilities**: Reserved for future Codex parity. External Gmail, Hey, and Google Calendar workflows are intentionally excluded from active Codex dispatch until the migration reaches end-to-end parity.\n**Skills**: `/email-triage`, `/meeting-prep`, `/weekly-agenda`, and `/deadline-radar` are likewise migration-gated in the current Codex runtime. `/contact-sync` remains separately active when `apple-contacts` MCP is configured.\n**Contact when**: In the current Codex runtime, do not dispatch external email/calendar work here. Explain the migration gate or capture future integration preferences instead.\n",
+    text,
+    count=1,
+    flags=re.S,
+)
+
+lines = text.splitlines()
+for idx, line in enumerate(lines):
+    if line.startswith("| `/email-triage` | Postman |"):
+        lines[idx] = "| `/email-triage` | Postman | Migration-gated in Codex; reserved for future email scanning parity |"
+    elif line.startswith("| `/meeting-prep` | Postman |"):
+        lines[idx] = "| `/meeting-prep` | Postman | Migration-gated in Codex; reserved for future meeting brief parity |"
+    elif line.startswith("| `/weekly-agenda` | Postman |"):
+        lines[idx] = "| `/weekly-agenda` | Postman | Migration-gated in Codex; reserved for future external week aggregation |"
+    elif line.startswith("| `/deadline-radar` | Postman |"):
+        lines[idx] = "| `/deadline-radar` | Postman | Migration-gated in Codex; reserved for future external deadline aggregation |"
+    elif line.startswith('| "Cross-reference this with email" | Postman |'):
+        lines[idx] = '| "Cross-reference this with email" | Postman (migration-gated in Codex) |'
+
+path.write_text("\n".join(lines) + newline)
+PY
+}
+
+_cc_apply_codex_postman_gate_skill() {
+  local skill_name="$1" file="$2"
+  [[ -f "$file" ]] || return 0
+
+  local summary=''
+  case "$skill_name" in
+    email-triage)
+      summary='**This skill is migration-gated in the current Codex runtime. Do not execute email integration steps from this file.**'
+      ;;
+    meeting-prep)
+      summary='**This skill is migration-gated in the current Codex runtime. Do not execute external email/calendar enrichment from this file.**'
+      ;;
+    weekly-agenda)
+      summary='**This skill is migration-gated in the current Codex runtime. Do not execute external email/calendar aggregation from this file.**'
+      ;;
+    deadline-radar)
+      summary='**This skill is migration-gated in the current Codex runtime. Do not execute external deadline aggregation from this file.**'
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+
+  local section
+  section=$(cat <<EOF
+## Codex Migration Gate
+
+${summary}
+
+When a user asks for this workflow in Codex:
+1. Explain that the workflow is not enabled yet in the current Codex runtime.
+2. Offer to capture the user's intent or future integration preference in the vault if helpful.
+3. Do not run Gmail, Hey, Google Calendar, or email/calendar MCP commands from this file.
+EOF
+)
+
+  _cc_insert_after_frontmatter "$file" '## Codex Migration Gate' "$section"
+}
+
+_cc_apply_codex_postman_gate_agent() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+
+  if ! grep -q '## Codex Migration Gate' "$file"; then
+    perl -0pi -e 's|# Postman — Email & Calendar Intelligence Hub\n|# Postman — Email & Calendar Intelligence Hub\n\n## Codex Migration Gate\n\n**This agent is migration-gated in the current Codex runtime. Do not execute external email or calendar integrations from this file.**\n\nWhen a user asks for Postman behavior in Codex, explain that Gmail, Hey, and Google Calendar workflows are not enabled yet, offer to capture future preferences if useful, and stop before running email or calendar commands.\n\n|s' "$file"
+  fi
+
+  perl -0pi -e 's|The Postman has nine operating modes\..*?what the user wants to do:|The Postman has nine operating modes in the legacy design. In the current Codex migration runtime, do not enter these modes. If the context is not clear, explain that the Postman runtime is migration-gated instead of asking the user to proceed through these modes.|s' "$file"
+}
+
 adapter_translate_dispatcher() {
   local src="$1" dst="$2"
   [[ -f "$src" ]] || return 0
@@ -158,12 +407,99 @@ adapter_translate_dispatcher() {
   cp "$src" "$dst/AGENTS.md"
   rewrite_codex_paths "$dst/AGENTS.md"
   normalize_codex_routing_contract "$dst/AGENTS.md"
+  _cc_apply_codex_postman_gate_dispatcher "$dst/AGENTS.md"
+  _cc_prune_dispatcher_appendix "$dst/AGENTS.md"
   _cc_prepend_codex_header "$dst/AGENTS.md"
 }
 
 # adapter_translate_references <source_refs_dir> <dest_root>
 # Copies *.md into dest_root/.codex/references/, rewriting framework paths
 # and normalizing Codex routing semantics.
+# _cc_rewrite_agent_template_reference <file>
+# Replaces the source markdown/YAML custom-agent template with a Codex-native
+# TOML template so the create-agent skill does not learn the wrong runtime.
+_cc_rewrite_agent_template_reference() {
+  local file="$1"
+  [[ -f "$file" ]] || return 0
+
+  cat > "$file" <<'EOF'
+# Custom Agent Template
+
+This file is the Codex-native reference template for the **Architect** when generating new custom agents.
+
+**Codex custom agents are TOML files** in `.codex/agents/`, not Markdown prompt files.
+
+---
+
+## Template
+
+```toml
+name = "{{agent-name}}"
+description = "{{One-paragraph description in the user's language, including trigger phrases they would naturally say.}}"
+model = "{{gpt-5.4|gpt-5.4-mini|gpt-5.3-codex-spark}}"
+model_reasoning_effort = "{{high|medium}}"
+sandbox_mode = "{{read-only|workspace-write}}"
+developer_instructions = '''
+# {{Agent Name}} — {{Short Subtitle}}
+
+Always respond to the user in their language.
+
+## User Profile
+
+Before doing anything, read `Meta/user-profile.md`.
+
+## Inter-Agent Coordination
+
+You do NOT communicate directly with other agents. The dispatcher handles all orchestration.
+
+### Suggested next agent
+- **Agent**: {{agent name from .codex/references/agents-registry.md}}
+- **Reason**: {{what needs to be done and why}}
+- **Context**: {{relevant details}}
+
+### Suggested new agent
+- **Need**: {{missing capability}}
+- **Reason**: {{why no existing agent can handle it}}
+- **Suggested role**: {{what the new agent would do}}
+
+For the full orchestration protocol, see `.codex/references/agent-orchestration.md`.
+For the agent registry, see `.codex/references/agents-registry.md`.
+
+## Core Responsibilities
+
+{{Detailed operating instructions, edge cases, output format, note templates, and examples.}}
+
+## First Run Setup
+
+{{How the agent detects first run, what it asks, and what it creates.}}
+
+## Agent State (Post-it)
+
+Read and write `Meta/states/{{agent-name}}.md` every run.
+
+## Operational Rules
+
+1. Always respond in the user's language.
+2. Read the user profile first.
+3. Be conservative by default.
+4. Follow vault naming conventions.
+5. Use Obsidian-compatible markdown and wikilinks.
+'''
+```
+
+---
+
+## Conventions for the Architect
+
+1. The `description` field is written only in the user's language.
+2. Start from minimal permissions and only grant `workspace-write` when the agent truly needs writes or shell operations.
+3. Every custom agent gets a row in `.codex/references/agents-registry.md` and a section in `.codex/references/agents.md`.
+4. File location: `.codex/agents/{{agent-name}}.toml`
+5. Complex multi-step flows should become skills in `.agents/skills/`, not nested child-agent logic.
+6. When in doubt, mirror the structure of the existing core `.codex/agents/*.toml` files.
+EOF
+}
+
 adapter_translate_references() {
   local src="$1" dst="$2"
   [[ -d "$src" ]] || return 0
@@ -179,6 +515,14 @@ adapter_translate_references() {
       continue
     fi
     normalize_codex_routing_contract "$out_file"
+    if [[ "$(basename "$f")" == "agents-registry.md" ]]; then
+      _cc_apply_codex_postman_gate_registry "$out_file"
+    elif [[ "$(basename "$f")" == "agents.md" ]]; then
+      _cc_apply_codex_postman_gate_agents_reference "$out_file"
+    fi
+    if [[ "$(basename "$f")" == "agent-template.md" ]]; then
+      _cc_rewrite_agent_template_reference "$out_file"
+    fi
   done
 }
 
@@ -191,6 +535,7 @@ _cc_rewrite_skill_markdown() {
 
   rewrite_codex_paths "$file"
   rewrite_tool_compat "$file"
+  _cc_apply_codex_postman_gate_skill "$skill_name" "$file"
 
   case "$skill_name" in
     onboarding)
@@ -201,9 +546,14 @@ _cc_rewrite_skill_markdown() {
         s/4\. Ask the NEXT question using ask the user/4. Ask the next direct plain-text question/g;
         s/\*\*ONE question per ask the user call\.\*\* Never bundle 2\+ questions in one message\./**One direct plain-text question at a time.** Never bundle 2+ questions in one message./g;
         s/\.codex\/agents\/\{name\}\.md/.codex\/agents\/{name}.toml/g;
+        s/\.codex\/agents\/([a-z-]+)\.md/.codex\/agents\/$1.toml/g;
+        s/"\$AGENT_SOURCE"\/([a-z-]+)\.md/"\$AGENT_SOURCE"\/$1.toml/g;
         s/\.mcp\.json/.codex\/config.toml/g;
         s/\$HOME\/\.platform\/agents/\$HOME\/.codex\/agents/g;
+        s/copy the `\.md` files from the `agents\/` folder of the plugin into `\.codex\/agents\/` inside your vault/copy the generated `.toml` files from `dist\/codex-cli\/.codex\/agents\/` inside the repo into `\.codex\/agents\/` inside your vault/g;
       ' "$file"
+      perl -0pi -e "s|cat > \.codex/config\.toml << 'EOF'\n\{\n  \"mcpServers\": \\{\n    \"Gmail\": \\{\n      \"type\": \"http\",\n      \"url\": \"https://gmail\.mcp\.claude\.com/mcp\"\n    \\},\n    \"Google Calendar\": \\{\n      \"type\": \"http\",\n      \"url\": \"https://gcal\.mcp\.claude\.com/mcp\"\n    \\}\n  \\}\n\}\nEOF|cat > .codex/config.toml << 'EOF'\n[mcp_servers.Gmail]\nurl = \"https://gmail.mcp.claude.com/mcp\"\n\n[mcp_servers.\"Google Calendar\"]\nurl = \"https://gcal.mcp.claude.com/mcp\"\nEOF|sg" "$file"
+      perl -0pi -e 's/\x60\x60\x60json\n\{\n  "mcpServers": \{\n    "Gmail": \{\n      "type": "http",\n      "url": "https:\/\/gmail\.mcp\.claude\.com\/mcp"\n    \},\n    "Google Calendar": \{\n      "type": "http",\n      "url": "https:\/\/gcal\.mcp\.claude\.com\/mcp"\n    \}\n  \}\n\}\n\x60\x60\x60/```toml\n[mcp_servers.Gmail]\nurl = "https:\/\/gmail.mcp.claude.com\/mcp"\n\n[mcp_servers."Google Calendar"]\nurl = "https:\/\/gcal.mcp.claude.com\/mcp"\n```/sg' "$file"
       ;;
     create-agent)
       perl -0pi -e '
@@ -295,14 +645,16 @@ adapter_translate_skills() {
 }
 
 # _cc_toml_quote_key <name>
-# Emits the TOML table key for [mcp_servers.<name>].
-# Codex CLI requires MCP server names to match ^[a-zA-Z0-9_-]+$, so any
-# character outside that set is replaced with a hyphen before writing.
+# Emits a TOML table key for [mcp_servers.<name>], preserving the original
+# server name. Bare keys are used for simple names; quoted keys are emitted for
+# names with spaces or punctuation.
 _cc_toml_quote_key() {
   local name="$1"
-  # Sanitize: replace any character not in [a-zA-Z0-9_-] with a hyphen
-  local safe_name="${name//[^a-zA-Z0-9_-]/-}"
-  printf '[mcp_servers.%s]' "$safe_name"
+  if [[ "$name" =~ ^[A-Za-z0-9_-]+$ ]]; then
+    printf '[mcp_servers.%s]' "$name"
+  else
+    printf '[mcp_servers."%s"]' "$(_cc_toml_escape_string "$name")"
+  fi
 }
 
 # _cc_toml_escape_string <value>
@@ -595,6 +947,7 @@ adapter_translate_agent_toml() {
   [[ -z "$name" ]] && name="$(basename "$agent_file" .md)"
 
   local description; description="$(_cc_extract_description "$agent_file")"
+  description="$(_cc_override_agent_description_for_codex "$name" "$description")"
   local desc_escaped; desc_escaped="$(_cc_toml_escape_dquote_string "$description")"
   local model_raw; model_raw="$(parse_frontmatter "$agent_file" model)"
   local model; model="$(_cc_model_to_codex "$model_raw")"
@@ -630,6 +983,9 @@ adapter_translate_agent_toml() {
       printf '%s\n' "$escaped_body"
       printf '"""\n'
     } > "$out_file"
+    if [[ "$name" == "postman" ]]; then
+      _cc_apply_codex_postman_gate_agent "$out_file"
+    fi
   else
     # Preferred: multiline literal string — no escaping needed
     {
@@ -642,6 +998,9 @@ adapter_translate_agent_toml() {
       printf '%s\n' "$body"
       printf "'''\n"
     } > "$out_file"
+    if [[ "$name" == "postman" ]]; then
+      _cc_apply_codex_postman_gate_agent "$out_file"
+    fi
   fi
 }
 

--- a/adapters/codex-cli/adapter.sh
+++ b/adapters/codex-cli/adapter.sh
@@ -105,7 +105,7 @@ normalize_codex_routing_contract() {
     s/follow the skill instructions directly in the root context via the `Skill` tool/follow the skill instructions directly in the root context/g;
     s/\(Skill tool\)/(root-context skill flow)/g;
     s/\(Agent tool\)/(bounded child agent)/g;
-    s/YES \+ not in chain \+ depth < 3 → INVOKE next/YES + not already handled → the root context decides whether another bounded child task is still necessary/g;
+    s/YES \+ not in chain \+ depth < 3 → INVOKE next/YES + not already handled + obvious\/low-risk → the root context continues with another bounded child task/g;
     s/- \*\*Max depth 3\*\*: no more than 3 agents per user request/- **Child depth: `agents.max_depth = 1`**: the root context may spawn one bounded child task, then decides the next step itself/g;
   ' "$file"
 }
@@ -130,8 +130,8 @@ _cc_prepend_codex_header() {
 > **Context:** Codex CLI loads this file as the root dispatcher. Due to
 > multi-agent depth limits (`agents.max_depth = 1` by default), all
 > orchestration decisions stay in this root context. Spawned agents emit
-> a `### Suggested next agent` signal; the root context then decides whether
-> to continue with another agent.
+> `### Suggested next agent` signals, and the root context should usually
+> continue through obvious, low-risk follow-up work before returning to the user.
 
 **Custom agents** live in `.codex/agents/*.toml` and are discovered automatically.
 **Skills** live in `.agents/skills/` inside the project (or `$HOME/.agents/skills/`).

--- a/docs/codex-cli.md
+++ b/docs/codex-cli.md
@@ -46,15 +46,23 @@ After running `launchme.sh --platform codex-cli`, your vault will contain:
 ```
 your-vault/
 ├── .codex/
-│   ├── agents/          ← 8 core crew agents (.toml format)
+│   ├── agents/          ← 8 core agent files (7 active + 1 migration-gated Postman role)
 │   ├── references/      ← shared docs the agents read
 │   └── config.toml      ← MCP server definitions + profiles + sandbox policy
 ├── .agents/
-│   └── skills/          ← 14 specialized skills (plain text instructions)
+│   └── skills/          ← 14 skill definitions (10 active + 4 migration-gated Postman skills)
 ├── Meta/
 │   └── scripts/         ← orchestra scripts (permission-free agent commands)
 └── AGENTS.md            ← dispatcher (project instructions for Codex)
 ```
+
+## Current Codex scope
+
+The current Codex runtime is intentionally narrower than the full cross-platform source tree:
+
+- Active agents: `architect`, `scribe`, `sorter`, `seeker`, `connector`, `librarian`, `transcriber`
+- Active skills: `/onboarding`, `/create-agent`, `/manage-agent`, `/defrag`, `/transcribe`, `/vault-audit`, `/deep-clean`, `/tag-garden`, `/inbox-triage`, `/contact-sync`
+- Migration-gated until external integration parity lands: `postman`, `/email-triage`, `/meeting-prep`, `/weekly-agenda`, `/deadline-radar`
 
 Key differences from other platforms:
 
@@ -137,15 +145,15 @@ Use this table to verify the Crew works correctly in a real Codex vault after in
 | Agent | Connector | `@Connector Find connections in my recent notes` | Connector analyzes the vault graph and suggests wikilinks |
 | Agent | Librarian | `@Librarian Run a vault health check` | Librarian scans for broken links, duplicates, and orphan notes |
 | Agent | Transcriber | `@Transcriber Process this transcript: [paste text]` | Transcriber generates structured meeting notes |
-| Agent | Postman | `@Postman Check my email` | Postman scans Gmail (or Hey) and saves actionable emails, or reports missing integration |
+| Agent | Postman | `@Postman Check my email` | Dispatcher explains that Postman is migration-gated in Codex and does not enter external email/calendar workflows |
 | Skill | onboarding | `/onboarding` | Architect starts the full onboarding conversation |
 | Skill | create-agent | `/create-agent` | Architect walks through designing a new custom agent |
 | Skill | manage-agent | `/manage-agent` | Architect lists, edits, or removes custom agents |
 | Skill | defrag | `/defrag` | Architect runs the 5-phase vault defragmentation |
-| Skill | email-triage | `/email-triage` | Postman scans and prioritizes unread emails |
-| Skill | meeting-prep | `/meeting-prep` | Postman generates a comprehensive meeting brief |
-| Skill | weekly-agenda | `/weekly-agenda` | Postman produces a day-by-day week overview |
-| Skill | deadline-radar | `/deadline-radar` | Postman produces a unified deadline timeline |
+| Skill | email-triage | `/email-triage` | Dispatcher explains that email triage is migration-gated in Codex |
+| Skill | meeting-prep | `/meeting-prep` | Dispatcher explains that meeting-email/calendar enrichment is migration-gated in Codex |
+| Skill | weekly-agenda | `/weekly-agenda` | Dispatcher explains that external week aggregation is migration-gated in Codex |
+| Skill | deadline-radar | `/deadline-radar` | Dispatcher explains that external deadline aggregation is migration-gated in Codex |
 | Skill | transcribe | `/transcribe` | Transcriber processes a recording or transcript into structured notes |
 | Skill | vault-audit | `/vault-audit` | Librarian runs the full 7-phase vault audit |
 | Skill | deep-clean | `/deep-clean` | Librarian runs the extended vault cleanup |
@@ -199,7 +207,7 @@ Expected: lists MCP servers from `.codex/config.toml` (e.g., `Gmail`, `Calendar`
 
 - MCP configuration lives in `.codex/config.toml` (not `.mcp.json`).
 - Check `codex -C <vault> mcp list` to see the current server status.
-- For Gmail/Calendar setup, see `docs/gws-setup-guide.md`.
+- Gmail and Google Calendar entries may still appear in `.codex/config.toml`, but the corresponding Postman workflows are migration-gated in the current Codex runtime.
 - For Apple Contacts, verify the `apple-contacts` server entry in `.codex/config.toml`.
 
 ### Codex errors about approvals

--- a/docs/codex-migration.md
+++ b/docs/codex-migration.md
@@ -47,10 +47,10 @@ After running `launchme.sh --platform codex-cli`, the Codex files are installed 
    ```
 
 3. The installer creates:
-   - `.codex/agents/` — all 8 core agents in TOML format
-   - `.agents/skills/` — all 14 skills as plain text instructions
+   - `.codex/agents/` — all 8 core agent files in TOML format, with `postman` marked migration-gated in the active Codex runtime
+   - `.agents/skills/` — all 14 skill definitions, with the 4 Postman skills marked migration-gated until external integration parity lands
    - `.codex/config.toml` — MCP servers (translated from `mcp/servers.yaml`)
-   - `AGENTS.md` — dispatcher with Codex routing header
+   - `AGENTS.md` — dispatcher with Codex routing header and migration-gated Postman contract
 
 4. Your existing `.claude/` directory and `CLAUDE.md` are left untouched.
 
@@ -73,7 +73,7 @@ After running `launchme.sh --platform codex-cli`, the Codex files are installed 
    bash scripts/launchme.sh --platform codex-cli
    ```
 
-3. The installer creates the full Codex layout (same as above).
+3. The installer creates the full Codex layout (same as above), including the same active-vs-migration-gated runtime contract.
 
 4. Your existing `.gemini/` directory and `GEMINI.md` are left untouched.
 
@@ -145,8 +145,8 @@ After running the installer, verify the Codex layout with these commands:
 ### Check that files installed correctly
 
 ```bash
-ls <vault>/.codex/agents/       # Should list *.toml files for all 8 agents
-ls <vault>/.agents/skills/      # Should list subdirectories for all 14 skills
+ls <vault>/.codex/agents/       # Should list *.toml files for all 8 agents (7 active + postman gated)
+ls <vault>/.agents/skills/      # Should list subdirectories for all 14 skills (10 active + 4 gated)
 ls <vault>/.codex/config.toml   # Should exist with [mcp_servers.*] tables
 ls <vault>/AGENTS.md            # Should exist with Codex routing header
 ```
@@ -169,4 +169,4 @@ Expected: lists MCP servers from `.codex/config.toml`.
 
 ### Run the full runtime smoke matrix
 
-See [docs/codex-cli.md — Runtime smoke matrix](codex-cli.md#runtime-smoke-matrix) for the complete list of agents, skills, chaining, and MCP checks.
+See [docs/codex-cli.md — Runtime smoke matrix](codex-cli.md#runtime-smoke-matrix) for the complete list of active agents, migration-gated units, chaining, and MCP checks.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -120,11 +120,11 @@ your-vault/
 ```
 your-vault/
 ├── .codex/
-│   ├── agents/          ← 8 core agents (.toml format)
+│   ├── agents/          ← 8 core agent files (7 active + 1 migration-gated Postman role)
 │   ├── references/      ← shared docs
 │   └── config.toml      ← MCP servers + profiles + sandbox policy
 ├── .agents/
-│   └── skills/          ← 14 specialized skills
+│   └── skills/          ← 14 skill definitions (10 active + 4 migration-gated Postman skills)
 ├── AGENTS.md            ← dispatcher
 ├── My-Brain-Is-Full-Crew/  ← the repo (for future updates)
 └── ... your Obsidian notes
@@ -170,12 +170,12 @@ The `/onboarding` skill will kick in and the **Architect** will start a friendly
 
 ### About your vault
 - Are you new to Obsidian, or migrating from an existing vault?
-- Do you want all 8 agents, or just some?
+- Do you want all active agents, or just some?
 - What areas of your life do you want to manage?
 
 ### About integrations (optional)
-- Do you want email triage? (requires Gmail via GWS/MCP, or Hey.com via Hey CLI)
-- Do you want calendar integration? (requires Google Calendar via GWS/MCP)
+- Do you want email preferences recorded for a future Postman migration phase?
+- Do you want calendar preferences recorded for a future Postman migration phase?
 
 After the conversation, the Architect creates your entire vault structure, saves your profile, and leaves you a personalized welcome note.
 
@@ -201,10 +201,10 @@ The **Scribe** will turn this into a clean note in your inbox.
 
 The **Scribe** detects multiple items and creates separate notes for each.
 
-### Check your email
-> "Check my email for anything important"
+### Ask about future integrations
+> "Do we already support email triage in Codex?"
 
-The `/email-triage` skill scans your inbox (Gmail or Hey.com), saves actionable emails, and gives you a summary.
+The dispatcher explains that Postman workflows are migration-gated for now. On Claude Code, Gemini CLI, and OpenCode, `/email-triage` remains the active email workflow.
 
 ### File everything
 > "Triage my inbox"
@@ -223,7 +223,7 @@ The **Seeker** searches your vault and synthesizes an answer with source citatio
 The Crew works best with simple daily routines:
 
 ### Morning (2 minutes)
-> "Check my calendar for today" to see what's ahead
+> "What needs my attention today?" to see what the active vault agents already know
 > "Any messages from the crew?" to check if agents flagged anything
 
 ### Throughout the day
@@ -243,11 +243,13 @@ The Crew works best with simple daily routines:
 Make sure your agent platform is open inside your vault folder (not a different directory). Verify agent files exist in the platform's agents directory (e.g., `.claude/agents/`). Try saying the trigger phrase differently. Agents and skills understand natural language in multiple languages.
 
 ### "Email/Calendar isn't working"
-The Postman needs at least one email backend: GWS CLI (`gws`), Hey CLI (`hey`), or MCP connectors. For GWS, see `docs/gws-setup-guide.md`. For Hey, install from [github.com/basecamp/hey-cli](https://github.com/basecamp/hey-cli) and run `hey auth login`.
+On **Codex CLI**, that is expected in the current migration runtime: Postman workflows are intentionally migration-gated. You can still record future email/calendar preferences during onboarding, but live email/calendar automation is not active yet.
+
+On **Claude Code, Gemini CLI, and OpenCode**, the Postman needs at least one email backend: GWS CLI (`gws`), Hey CLI (`hey`), or MCP connectors. For GWS, see `docs/gws-setup-guide.md`. For Hey, install from [github.com/basecamp/hey-cli](https://github.com/basecamp/hey-cli) and run `hey auth login`.
 
 For MCP connectors:
 - **Claude Code / OpenCode**: run the installer again (`bash scripts/launchme.sh`) and answer **yes** to the Gmail/Calendar question, or manually add the servers to your `.mcp.json` at the vault root.
-- **Codex CLI**: MCP servers are configured in `.codex/config.toml` (not `.mcp.json`). Run `bash scripts/launchme.sh --platform codex-cli` and the installer writes them automatically. See [docs/codex-cli.md](codex-cli.md) for the full MCP setup details.
+- **Codex CLI**: MCP servers are configured in `.codex/config.toml` (not `.mcp.json`) for future parity and for active servers such as Apple Contacts. See [docs/codex-cli.md](codex-cli.md) for the current Codex scope.
 
 ### "My vault structure looks different from the docs"
 The Architect customizes the structure based on your onboarding answers.

--- a/mcp/servers.yaml
+++ b/mcp/servers.yaml
@@ -4,7 +4,7 @@ servers:
     url: "https://gmail.mcp.claude.com/mcp"
     env: {}
     exclude: []
-  - name: Google-Calendar
+  - name: Google Calendar
     type: http
     url: "https://gcal.mcp.claude.com/mcp"
     env: {}

--- a/references/agent-orchestration.md
+++ b/references/agent-orchestration.md
@@ -6,16 +6,16 @@ This document defines how agents coordinate through the **dispatcher** (`DISPATC
 
 ## Overview
 
-The dispatcher is a **reactive multi-router** with skill-first routing:
+The dispatcher is an **offload-first multi-router** with skill-first routing:
 
 1. **User sends a message** → dispatcher checks the **skill routing table** first
 2. **Skill match found?** → invoke the skill via the **Skill tool** and respond to user
 3. **No skill match?** → dispatcher picks the best **agent** by priority
 4. **Agent executes** → returns output to the dispatcher
-5. **Dispatcher reads the output** → decides if another agent should be chained
+5. **Dispatcher reads the output** → continues through obvious low-risk follow-up work when appropriate
 6. **Repeat** until done or max depth reached
 
-Agents help the dispatcher by including **suggestions** in their output when they detect work for other agents.
+Agents help the dispatcher by including **suggestions** in their output when they detect work for other agents. These suggestions are primarily dispatcher inputs, not default user-facing to-do items.
 
 ---
 
@@ -34,7 +34,8 @@ Skills are checked **before** agents. They handle complex, multi-step workflows 
 
 Skills can still produce output that triggers agent chaining:
 - A skill may include `### Suggested next agent` in its output (e.g., `/onboarding` may suggest Connector to link newly created notes).
-- The dispatcher reads this output and applies the same chaining rules as for agents (check registry, check call chain, max depth 3).
+- The dispatcher reads this output and applies the same chaining rules as for agents.
+- If the suggested follow-up is obvious, low-risk, and well-scoped, the dispatcher should continue automatically instead of bouncing the choice back to the user.
 - Skills count as step 1 in the call chain when they produce agent suggestions.
 
 ### List of skills
@@ -55,6 +56,8 @@ When an agent detects work that another agent should handle, it includes a secti
 ```
 
 Multiple suggestions are allowed — list them all. The dispatcher prioritizes and decides which (if any) to invoke.
+
+For obvious low-risk follow-up work, the default expectation is that the dispatcher continues the chain and returns completed results to the user. The dispatcher should stop and ask only when the next step is ambiguous, risky, unsupported, or preference-sensitive.
 
 ### Examples
 
@@ -101,10 +104,12 @@ After each agent returns, the dispatcher:
 1. **Reads the output** — looks for `### Suggested next agent` sections
 2. **Consults `agents-registry.md`** — validates the suggested agent exists and is `active`
 3. **Checks the call chain** — is this agent already in the chain? Is max depth reached?
-4. **Checks for `### Suggested new agent`** -- if present, asks the user if they want the Architect to create a custom agent
-5. **Decides**: invoke next agent OR return results to user
+4. **Applies the offload-first gate** — continue automatically only if the next step is obvious, low-risk, and has enough context
+5. **Checks for stop conditions** — ambiguity, destructive edits, structural surprises, unsupported capability, or missing user preference
+6. **Checks for `### Suggested new agent`** -- if present, asks the user if they want the Architect to create a custom agent
+7. **Decides**: invoke next agent OR return results to user
 
-The dispatcher can also chain agents **without an explicit suggestion** if the output clearly matches another agent's capabilities (e.g., notes created → Sorter might be needed).
+The dispatcher can also chain agents **without an explicit suggestion** if the output clearly matches another agent's capabilities (e.g., notes created → Sorter might be needed) and the same offload-first gate is satisfied.
 
 ---
 
@@ -121,6 +126,20 @@ Every user request has a **call chain** — the ordered list of agents invoked s
 5. **No circular patterns**: if Agent A suggests Agent B and B is already in the chain, skip
 6. **Max depth: 3**: no more than 3 agents per user request
 7. **On overflow**: return results to user with a note about what was deferred
+
+### Continue Criteria
+
+Continue automatically when all of these are true:
+- The next step is the normal consequence of the completed step
+- The next agent has enough concrete context to act
+- The follow-up is bounded and unlikely to surprise the user
+- No unsupported or migration-gated capability is involved
+
+Stop and ask the user when any of these are true:
+- More than one reasonable next move exists
+- The work would delete, archive, rename, or restructure in a surprising way
+- The next step depends on a user preference or policy choice not yet stated
+- The agent output indicates uncertainty or incomplete context
 
 ### What Happens at Max Depth
 
@@ -149,6 +168,7 @@ Custom agents are created by the Architect and stored in `.platform/agents/`. Th
 - ❌ **Do NOT edit other agents' prompt/config files** (e.g., `.platform/agents/*.md`) — normal vault notes/MOC edits are still allowed per your responsibilities; all coordination goes through the dispatcher
 - ❌ **Do NOT block waiting for another agent** — finish your task and suggest next steps in your output
 - ❌ **Do NOT call other agents** — only the dispatcher invokes agents
+- ❌ **Do NOT frame every suggestion as user homework** — provide context rich enough for the dispatcher to continue when the next step is obvious
 
 ---
 

--- a/references/agent-template.md
+++ b/references/agent-template.md
@@ -57,7 +57,7 @@ Before doing anything, read `Meta/user-profile.md` to understand the user's cont
 
 > **You do NOT communicate directly with other agents. The dispatcher handles all orchestration.**
 
-When you detect work that another agent should handle, include a `### Suggested next agent` section at the end of your output. The dispatcher reads this and decides whether to chain the next agent.
+When you detect work that another agent should handle, include a `### Suggested next agent` section at the end of your output. The dispatcher reads this and decides whether to chain the next agent. Treat this section as dispatcher continuation input: provide enough concrete context that the dispatcher can often continue automatically when the next step is obvious and low-risk.
 
 ### When to suggest another agent
 
@@ -76,6 +76,11 @@ When you detect work that another agent should handle, include a `### Suggested 
 - **Reason**: {{what needs to be done and why}}
 - **Context**: {{relevant details -- note titles, folder paths, specific issues}}
 ~~~
+
+**Quality bar for suggestions:**
+- Write them so the dispatcher can act without asking the user to manually drive the next step
+- Include the exact notes, folders, or issues that make the follow-up obvious
+- Avoid vague suggestions like "maybe connect these later" unless the follow-up is genuinely uncertain
 
 ### When to suggest a new agent
 

--- a/references/codex-cli-compat.md
+++ b/references/codex-cli-compat.md
@@ -11,8 +11,8 @@ Use this reference when source workflows mention platform-specific tools or recu
 | `AskUserQuestion` | Ask a direct plain-text question in chat and wait for the reply | Codex uses the root conversation for confirmations and follow-up questions. |
 | `request_user_input` | Ask a direct plain-text question in chat and wait for the reply | Use the same root-thread confirmation flow as any other user interaction. |
 | `Skill tool` | Follow the relevant skill instructions directly in the root context | Skills stay in the main chat; do not invent a separate Skill API. |
-| `Agent tool` | Use `spawn_agent` only for bounded child tasks | The root context keeps orchestration and integration decisions. |
-| `max chain depth 3` | `agents.max_depth = 1` with root-only orchestration | A child can finish one bounded task; any next step is decided back in the root context. |
+| `Agent tool` | Use `spawn_agent` only for bounded child tasks | The root context keeps orchestration and integration decisions and may continue through multiple bounded follow-up steps serially. |
+| `max chain depth 3` | `agents.max_depth = 1` with root-only orchestration | This blocks deep child recursion, not root-side serial orchestration. The root can still continue obvious low-risk follow-up work one bounded child at a time. |
 | `.mcp.json` | `.codex/config.toml` | Codex MCP and profile settings live in the TOML config. |
 
 ## Flattened Workflow Example
@@ -27,12 +27,13 @@ Codex CLI wording:
 
 1. Ask the user directly in chat and wait for the reply.
 2. Keep the setup flow in the root context by following the skill instructions directly.
-3. If a bounded side task remains, use `spawn_agent`, then return to the root context to decide what happens next.
+3. If a bounded side task remains, use `spawn_agent`, then let the root context continue through obvious low-risk follow-up work before returning to the user.
 
 ## Troubleshooting
 
 - Child approvals surface in the child thread. Approve or deny there, then continue orchestration from the root context after the child returns.
 - If a task would require deeper recursion, stop spawning children and flatten the next step into the root context or split the work into separate bounded child tasks.
+- Offload-first does not mean forceful. The root should still stop for ambiguity, destructive edits, unsupported capabilities, or missing user preference decisions.
 - Codex custom agents live in `.codex/agents/*.toml`.
 - Repo-scoped Codex skills live in `.agents/skills/`.
 - MCP servers, approval policy, sandbox mode, and profiles live in `.codex/config.toml`.

--- a/tests/adapters/codex-cli/adapter.test.sh
+++ b/tests/adapters/codex-cli/adapter.test.sh
@@ -276,6 +276,33 @@ test_cc_real_dispatcher_marks_postman_migration_gated() {
   return $result
 }
 
+test_cc_real_dispatcher_uses_offload_first_codex_contract() {
+  local dst; dst="$(mktemp -d)"
+  adapter_translate_dispatcher "$ROOT/DISPATCHER.md" "$dst"
+  adapter_translate_references "$ROOT/references" "$dst"
+
+  local dispatcher; dispatcher="$(cat "$dst/AGENTS.md")"
+  local compat; compat="$(cat "$dst/.codex/references/codex-cli-compat.md")"
+  local result=0
+
+  [[ "$dispatcher" == *'The dispatcher is an **offload-first multi-router**.'* ]] \
+    || { echo 'dispatcher should describe Codex as offload-first'; result=1; }
+  [[ "$dispatcher" == *'continue through obvious, low-risk follow-up work before returning to the user'* ]] \
+    || { echo 'dispatcher header should prefer obvious low-risk continuation'; result=1; }
+  [[ "$dispatcher" == *'### Continue vs stop'* ]] \
+    || { echo 'dispatcher should define continue-vs-stop rules'; result=1; }
+  [[ "$dispatcher" == *'primarily for dispatcher continuation'* ]] \
+    || { echo 'dispatcher should frame Suggested next agent as continuation input'; result=1; }
+
+  [[ "$compat" == *'This blocks deep child recursion, not root-side serial orchestration.'* ]] \
+    || { echo 'compat guide should clarify root-side serial orchestration'; result=1; }
+  [[ "$compat" == *'Offload-first does not mean forceful.'* ]] \
+    || { echo 'compat guide should preserve the non-forceful guardrail'; result=1; }
+
+  rm -rf "$dst"
+  return $result
+}
+
 test_cc_real_registry_marks_postman_runtime_units_gated() {
   local dst; dst="$(mktemp -d)"
   adapter_translate_references "$ROOT/references" "$dst"

--- a/tests/adapters/codex-cli/adapter.test.sh
+++ b/tests/adapters/codex-cli/adapter.test.sh
@@ -256,6 +256,78 @@ test_cc_translate_skills_rewrites_high_risk_real_skills_for_codex() {
   return $result
 }
 
+
+test_cc_real_dispatcher_marks_postman_migration_gated() {
+  local dst; dst="$(mktemp -d)"
+  adapter_translate_dispatcher "$ROOT/DISPATCHER.md" "$dst"
+
+  local content; content="$(cat "$dst/AGENTS.md")"
+  local result=0
+  [[ "$content" == *'## Migration-Gated Units'* ]] \
+    || { echo 'dispatcher should declare migration-gated units'; result=1; }
+  [[ "$content" == *'`postman`'* && "$content" == *'`/email-triage`'* ]] \
+    || { echo 'dispatcher should list postman and email-triage as gated'; result=1; }
+  [[ "$content" == *'Migration-gated in Codex. Explain that external email/calendar integrations are not enabled yet.'* ]] \
+    || { echo 'dispatcher should gate the postman fallback row'; result=1; }
+  [[ "$content" != *'Calendar import, create event, targeted email/calendar search, VIP filter, email draft'* ]] \
+    || { echo 'dispatcher should not keep the active postman routing copy'; result=1; }
+
+  rm -rf "$dst"
+  return $result
+}
+
+test_cc_real_registry_marks_postman_runtime_units_gated() {
+  local dst; dst="$(mktemp -d)"
+  adapter_translate_references "$ROOT/references" "$dst"
+
+  local content; content="$(cat "$dst/.codex/references/agents-registry.md")"
+  local result=0
+  [[ "$content" == *'| postman | Email & Calendar Intelligence | Reserved for future Codex parity.'* ]] \
+    || { echo 'registry should rewrite postman to migration-gated text'; result=1; }
+  [[ "$content" == *'| `/email-triage` | postman '* && "$content" == *'| migration-gated |'* ]] \
+    || { echo 'registry should mark email-triage as migration-gated'; result=1; }
+  [[ "$content" == *'| `/meeting-prep` | postman '* && "$content" == *'meeting email/calendar enrichment is migration-gated'* ]] \
+    || { echo 'registry should mark meeting-prep as migration-gated'; result=1; }
+  [[ "$content" == *'**migration-gated**: Agent or skill is intentionally excluded from active Codex dispatch'* ]] \
+    || { echo 'registry should document the migration-gated status value'; result=1; }
+
+  rm -rf "$dst"
+  return $result
+}
+
+test_cc_real_postman_runtime_files_have_codex_migration_gates() {
+  local dst; dst="$(mktemp -d)"
+  adapter_translate_agents_toml "$ROOT/agents" "$dst"
+  adapter_translate_skills "$ROOT/skills" "$dst"
+
+  local result=0
+  local postman="$dst/.codex/agents/postman.toml"
+  [[ -f "$postman" ]] || { echo 'missing generated postman.toml'; rm -rf "$dst"; return 1; }
+  local content; content="$(cat "$postman")"
+  [[ "$content" == *'Migration-gated placeholder for future email and calendar parity in Codex.'* ]] \
+    || { echo 'postman description should be overridden for Codex'; result=1; }
+  [[ "$content" == *'## Codex Migration Gate'* ]] \
+    || { echo 'postman.toml should include a migration gate section'; result=1; }
+  [[ "$content" != *'.mcp.json'* ]] \
+    || { echo 'postman.toml should not mention .mcp.json'; result=1; }
+
+  local skill
+  for skill in email-triage meeting-prep weekly-agenda deadline-radar; do
+    local skill_file="$dst/.agents/skills/$skill/SKILL.md"
+    [[ -f "$skill_file" ]] || { echo "missing generated $skill skill"; result=1; continue; }
+    content="$(cat "$skill_file")"
+    [[ "$content" == *'## Codex Migration Gate'* ]] \
+      || { echo "$skill should include a migration gate section"; result=1; }
+    [[ "$content" != *'.mcp.json'* ]] \
+      || { echo "$skill should not mention .mcp.json"; result=1; }
+    [[ "$content" != *'AskUserQuestion'* ]] \
+      || { echo "$skill should not leak AskUserQuestion into Codex runtime"; result=1; }
+  done
+
+  rm -rf "$dst"
+  return $result
+}
+
 test_cc_translate_skills_preserves_optional_directories_and_rewrites_text_files() {
   local src; src="$(mktemp -d)"
   local dst; dst="$(mktemp -d)"
@@ -1454,5 +1526,57 @@ EOF
     || { echo 'normalized output should mention the root-only Codex contract'; result=1; }
 
   rm -f "$tmp"
+  return $result
+}
+
+
+test_cc_real_dispatcher_prunes_source_appendix_and_stale_runtime_strings() {
+  local dst; dst="$(mktemp -d)"
+  adapter_build "$ROOT" "$dst"
+
+  local content; content="$(cat "$dst/AGENTS.md")"
+  local result=0
+  [[ "$content" != *'# Project Info'* ]] || { echo 'source appendix should not leak into Codex AGENTS.md'; result=1; }
+  [[ "$content" != *'.mcp.json'* ]] || { echo '.mcp.json should not appear in Codex AGENTS.md'; result=1; }
+  [[ "$content" != *'.codex/skills/'* ]] || { echo '.codex/skills/ should not appear in Codex AGENTS.md'; result=1; }
+  [[ "$content" != *'.codex/agents/{name}.md'* ]] || { echo '.codex/agents/{name}.md should not appear in Codex AGENTS.md'; result=1; }
+
+  rm -rf "$dst"
+  return $result
+}
+
+test_cc_real_onboarding_skill_uses_codex_runtime_examples() {
+  local dst; dst="$(mktemp -d)"
+  adapter_build "$ROOT" "$dst"
+
+  local skill="$dst/.agents/skills/onboarding/SKILL.md"
+  local content; content="$(cat "$skill")"
+  local result=0
+  [[ "$content" == *'.codex/config.toml'* ]] || { echo 'onboarding should mention .codex/config.toml'; result=1; }
+  [[ "$content" == *'[mcp_servers.Gmail]'* ]] || { echo 'onboarding should show TOML MCP example'; result=1; }
+  [[ "$content" != *'mcpServers'* ]] || { echo 'onboarding should not show JSON mcpServers example'; result=1; }
+  [[ "$content" != *'.mcp.json'* ]] || { echo 'onboarding should not mention .mcp.json'; result=1; }
+  [[ "$content" != *'"$AGENT_SOURCE"/architect.md'* ]] || { echo 'onboarding should not copy .md agent files in Codex mode'; result=1; }
+  [[ "$content" != *'.codex/agents/architect.md'* ]] || { echo 'onboarding should not reference .md agent runtime paths'; result=1; }
+  [[ "$content" == *'architect.toml'* ]] || { echo 'onboarding should reference .toml agent files'; result=1; }
+
+  rm -rf "$dst"
+  return $result
+}
+
+test_cc_real_agent_template_is_toml_native() {
+  local dst; dst="$(mktemp -d)"
+  adapter_build "$ROOT" "$dst"
+
+  local template="$dst/.codex/references/agent-template.md"
+  local content; content="$(cat "$template")"
+  local result=0
+  [[ "$content" == *'```toml'* ]] || { echo 'agent-template should use a TOML example'; result=1; }
+  [[ "$content" == *"developer_instructions = '''"* ]] || { echo 'agent-template should document developer_instructions'; result=1; }
+  [[ "$content" == *'.codex/agents/{{agent-name}}.toml'* ]] || { echo 'agent-template should point to .toml output'; result=1; }
+  [[ "$content" != *'```yaml'* ]] || { echo 'agent-template should not use YAML in Codex output'; result=1; }
+  [[ "$content" != *'.platform/'* ]] || { echo 'agent-template should not leak .platform paths'; result=1; }
+
+  rm -rf "$dst"
   return $result
 }


### PR DESCRIPTION
This PR closes the remaining gaps in the current Codex compatibility layer.

## What this changes

1. Runtime contract

The Codex adapter now generates a consistent runtime contract. MCP names that need quoted TOML keys, such as `Google Calendar`, are preserved correctly. The generated dispatcher, references, agent output, and skill output now agree on which parts of the Codex runtime are active today and which ones are still gated.

2. Postman scope

The current Codex runtime does not yet have full external email and calendar parity. This PR makes that explicit instead of implying that `postman`, `/email-triage`, `/meeting-prep`, `/weekly-agenda`, and `/deadline-radar` are fully available. Those flows are now clearly marked as migration gated in the generated Codex layer.

3. Documentation

The Codex facing docs now describe the real scope of the runtime. `README.md`, `docs/getting-started.md`, `docs/codex-cli.md`, and `docs/codex-migration.md` now explain what is active, what is planned for later parity, and how the Codex layout differs from the other platforms.

4. Regression coverage

The adapter tests now cover the migration gated Postman contract, dispatcher cleanup, TOML native examples, and quoted MCP table names. This makes future adapter work much less likely to drift silently.

## Why this matters

Before this change, the repository already had real Codex support, but the story was not fully consistent. Parts of the runtime were correct while some docs and generated output still suggested broader parity than Codex actually has today. That mismatch makes installs harder to trust and harder to maintain.

The goal of this PR is not to redesign the project. It is to make the current Codex path honest, stable, and easier to build on.

## Validation

`bash scripts/build.sh --platform codex-cli`

`bash tests/run.sh`

`bash tests/regression/run.sh`

## Scope

This PR stays intentionally narrow. It only changes source, docs, and tests that affect the Codex runtime contract. It does not include vault files, local planning files, or generated build artifacts.