### PR TITLE
feat: crew-state conflict awareness (#36)

### DIFF
--- a/agents/architect.md
+++ b/agents/architect.md
@@ -363,6 +363,8 @@ When you detect work that another agent should handle, include a `### Suggested 
 - **Connector** — "New MOC created; it should be linked to related MOCs"
 - **Postman** — "New project folder created; calendar events for this project should be imported"
 
+Before suggesting work for another agent, call engram_query scoped to that agent's domain to check what they already know — avoid duplicating work they've recorded.
+
 ### Output format for suggestions
 
 ```markdown
@@ -448,6 +450,8 @@ You have a personal post-it at `Meta/states/architect.md`. This is your memory b
 
 Read `Meta/states/architect.md` (if it exists). Check if there is an active flow in progress. If there is, **resume from the recorded phase** — do NOT restart the flow from scratch.
 
+Also call `engram_query` with topic `"vault structure decisions"` scoped to `"architect/findings"` to load any cross-agent structural discoveries. Keep the Post-it read — Engram is additive.
+
 ### At the END of every execution
 
 **You MUST write your post-it. This is not optional.** Write (or overwrite if it already exists) `Meta/states/architect.md` with:
@@ -471,5 +475,7 @@ last-run: "{{ISO timestamp}}"
 ### Summary: Created 02-Areas/Health/ with sub-folders, _index.md, MOC, templates
 ### Issues detected: 5 orphan notes in 03-Resources/ (suggested Connector)
 ```
+
+Also call `engram_commit` for any significant structural decisions, using scope `"architect/findings"`, `confidence: 0.9` for verified decisions or `0.7` for inferences, and `fact_type: "observation"` for facts found or `"decision"` for choices made. Keep the Post-it write intact — Engram is additive.
 
 **Max 30 lines** in the Post-it body. If you need more, summarize. This is a post-it, not a journal.

--- a/agents/connector.md
+++ b/agents/connector.md
@@ -46,6 +46,8 @@ When you detect work that another agent should handle, include a `### Suggested 
 - **Sorter** → when notes are clearly related to a project/area but not filed there
 - **Seeker** → when you need content-level verification before suggesting a connection
 
+Before suggesting work for another agent, call engram_query scoped to that agent's domain to check what they already know — avoid duplicating work they've recorded.
+
 ### Output format for suggestions
 
 ```markdown
@@ -366,6 +368,8 @@ You have a personal post-it at `Meta/states/connector.md`. This is your memory b
 
 Read `Meta/states/connector.md` if it exists. It contains notes you left for yourself last time — e.g., orphan notes you spotted, clusters you were analyzing, or link suggestions that were deferred. If the file does not exist, this is your first run — proceed without prior context.
 
+Also call `engram_query` with topic `"link gaps orphan clusters"` scoped to `"connector/findings"` to load any cross-agent graph discoveries. Keep the Post-it read — Engram is additive.
+
 ### At the END of every execution
 
 **You MUST write your post-it. This is not optional.** Write (or overwrite if it already exists) `Meta/states/connector.md` with:
@@ -382,5 +386,7 @@ last-run: "{{ISO timestamp}}"
 ```
 
 **What to save**: links you created, orphan notes still unconnected, emerging clusters or themes, MOCs that need updating, connection suggestions the user deferred.
+
+Also call `engram_commit` for any significant graph findings, using scope `"connector/findings"`, `confidence: 0.9` for verified findings or `0.7` for inferences, and `fact_type: "observation"` for facts found or `"decision"` for choices made. Keep the Post-it write intact — Engram is additive.
 
 **Max 30 lines** in the Post-it body. If you need more, summarize. This is a post-it, not a journal.

--- a/agents/librarian.md
+++ b/agents/librarian.md
@@ -48,6 +48,8 @@ When you detect work that another agent should handle, include a `### Suggested 
 - **Seeker** → when you find notes with conflicting or duplicate information that need a content-level reconciliation
 - **Scribe** → when notes are missing required frontmatter or are structurally malformed; ask Scribe to reformat them
 
+Before suggesting work for another agent, call engram_query scoped to that agent's domain to check what they already know — avoid duplicating work they've recorded.
+
 ### Legacy cleanup
 
 If the vault still has a `Meta/agent-messages.md` file from the old messaging system, rename it to `Meta/agent-messages-DEPRECATED.md` during maintenance. The new system uses dispatcher-driven orchestration — no shared message board.
@@ -309,6 +311,8 @@ You have a personal post-it at `Meta/states/librarian.md`. This is your memory b
 
 Read `Meta/states/librarian.md` if it exists. It contains notes you left for yourself last time — e.g., issues found in the last audit, areas that need attention, recurring problems. If the file does not exist, this is your first run — proceed without prior context.
 
+Also call `engram_query` with topic `"vault health issues findings"` scoped to `"librarian/findings"` to load any cross-agent discoveries relevant to your audit. Keep the Post-it read — Engram is additive.
+
 ### At the END of every execution
 
 **You MUST write your post-it. This is not optional.** Write (or overwrite if it already exists) `Meta/states/librarian.md` with:
@@ -325,5 +329,7 @@ last-run: "{{ISO timestamp}}"
 ```
 
 **What to save**: issues found this audit, problems fixed, recurring issues across audits, areas of the vault that are degrading, duplicate clusters you're tracking.
+
+Also call `engram_commit` for any significant findings, using scope `"librarian/findings"`, `confidence: 0.9` for verified findings or `0.7` for inferences, and `fact_type: "observation"` for facts found or `"decision"` for choices made. Keep the Post-it write intact — Engram is additive.
 
 **Max 30 lines** in the Post-it body. If you need more, summarize. This is a post-it, not a journal.

--- a/agents/postman.md
+++ b/agents/postman.md
@@ -63,6 +63,8 @@ When you detect work that another agent should handle, include a `### Suggested 
 - **Transcriber** → when you find a calendar event that has an associated recording link (Zoom, Meet, Teams) that should be transcribed
 - **Connector** → when an email thread references vault notes that should be cross-linked
 
+Before suggesting work for another agent, call engram_query scoped to that agent's domain to check what they already know — avoid duplicating work they've recorded.
+
 ### Output format for suggestions
 
 ```markdown
@@ -1242,6 +1244,8 @@ You have a personal post-it at `Meta/states/postman.md`. This is your memory bet
 
 Read `Meta/states/postman.md` if it exists. It contains notes you left for yourself last time — e.g., VIP contacts, email threads being tracked, upcoming deadlines, last inbox scan timestamp. If the file does not exist, this is your first run — proceed without prior context.
 
+Also call `engram_query` with topic `"email calendar import findings"` scoped to `"postman/findings"` to load any cross-agent email and calendar discoveries. Keep the Post-it read — Engram is additive.
+
 ### At the END of every execution
 
 **You MUST write your post-it. This is not optional.** Write (or overwrite if it already exists) `Meta/states/postman.md` with:
@@ -1258,5 +1262,7 @@ last-run: "{{ISO timestamp}}"
 ```
 
 **What to save**: last inbox scan timestamp, emails saved to vault, pending follow-ups, upcoming deadlines detected, VIP contacts identified, calendar events imported.
+
+Also call `engram_commit` for any significant findings, using scope `"postman/findings"`, `confidence: 0.9` for verified findings or `0.7` for inferences, and `fact_type: "observation"` for facts found or `"decision"` for choices made. Keep the Post-it write intact — Engram is additive.
 
 **Max 30 lines** in the Post-it body. If you need more, summarize. This is a post-it, not a journal.

--- a/agents/scribe.md
+++ b/agents/scribe.md
@@ -47,6 +47,8 @@ When you detect work that another agent should handle, include a `### Suggested 
 - **Sorter** → when a note is complex enough that the routing decision isn't obvious
 - **Connector** → when you notice the new note clearly relates to multiple existing notes but you don't have time to add links
 
+Before suggesting work for another agent, call engram_query scoped to that agent's domain to check what they already know — avoid duplicating work they've recorded.
+
 ### Output format for suggestions
 
 ```markdown
@@ -443,6 +445,8 @@ You have a personal post-it at `Meta/states/scribe.md`. This is your memory betw
 
 Read `Meta/states/scribe.md` if it exists. It contains notes you left for yourself last time. Use this context to provide continuity — e.g., if the user is continuing a brainstorm from earlier, you already know the topic. If the file does not exist, this is your first run — proceed without prior context.
 
+Also call `engram_query` with topic `"note capture patterns"` scoped to `"scribe/findings"` to load any cross-agent capture discoveries. Keep the Post-it read — Engram is additive.
+
 ### At the END of every execution
 
 **You MUST write your post-it. This is not optional.** Write (or overwrite if it already exists) `Meta/states/scribe.md` with:
@@ -459,5 +463,7 @@ last-run: "{{ISO timestamp}}"
 ```
 
 **What to save**: notes you created this session (titles + paths), any pending user requests, brainstorm topics in progress, assumptions you made that the user might revisit.
+
+Also call `engram_commit` for any significant findings, using scope `"scribe/findings"`, `confidence: 0.9` for verified findings or `0.7` for inferences, and `fact_type: "observation"` for facts found or `"decision"` for choices made. Keep the Post-it write intact — Engram is additive.
 
 **Max 30 lines** in the Post-it body. If you need more, summarize. This is a post-it, not a journal.

--- a/agents/seeker.md
+++ b/agents/seeker.md
@@ -48,6 +48,8 @@ The Seeker is often the agent that discovers unexpected things while searching. 
 - **Architect** → **MANDATORY.** When you notice ANY structural gap: folders that don't match `Meta/vault-structure.md`, notes that have no logical home, areas that are missing or incomplete, MOCs that are stale or missing. Include a detailed description of the inconsistency so the Architect can fix it. You are the agent that sees the vault most broadly during searches — your structural feedback is critical.
 - **Sorter** → when you find notes that are in the wrong place and should be re-filed
 
+Before suggesting work for another agent, call engram_query scoped to that agent's domain to check what they already know — avoid duplicating work they've recorded.
+
 ### Output format for suggestions
 
 ```markdown
@@ -364,6 +366,8 @@ You have a personal post-it at `Meta/states/seeker.md`. This is your memory betw
 
 Read `Meta/states/seeker.md` if it exists. It contains notes you left for yourself last time — e.g., recent searches the user ran, topics they keep coming back to, or gaps in the vault you noticed. If the file does not exist, this is your first run — proceed without prior context.
 
+Also call `engram_query` with topic `"vault search gaps"` scoped to `"seeker/findings"` to load any cross-agent search discoveries. Keep the Post-it read — Engram is additive.
+
 ### At the END of every execution
 
 **You MUST write your post-it. This is not optional.** Write (or overwrite if it already exists) `Meta/states/seeker.md` with:
@@ -380,5 +384,7 @@ last-run: "{{ISO timestamp}}"
 ```
 
 **What to save**: what the user searched for, what was found (or not found), vault gaps you detected, topics that keep recurring across searches.
+
+Also call `engram_commit` for any significant findings, using scope `"seeker/findings"`, `confidence: 0.9` for verified findings or `0.7` for inferences, and `fact_type: "observation"` for facts found or `"decision"` for choices made. Keep the Post-it write intact — Engram is additive.
 
 **Max 30 lines** in the Post-it body. If you need more, summarize. This is a post-it, not a journal.

--- a/agents/sorter.md
+++ b/agents/sorter.md
@@ -44,6 +44,8 @@ During triage, if you encounter a situation you can't fully resolve — **don't 
 - **Connector** → when you file a batch of notes that seem highly interconnected and should be cross-linked
 - **Seeker** → when you need to verify if a similar note already exists before creating wikilinks
 
+Before suggesting work for another agent, call engram_query scoped to that agent's domain to check what they already know — avoid duplicating work they've recorded.
+
 Always include your proposed solution and what you did in the meantime. Then **continue with the rest of the triage** — don't block.
 
 ### Output format for suggestions
@@ -310,6 +312,8 @@ You have a personal post-it at `Meta/states/sorter.md`. This is your memory betw
 
 Read `Meta/states/sorter.md` if it exists. It contains notes you left for yourself last time — e.g., files that were skipped, ambiguous notes you deferred, or patterns you noticed. If the file does not exist, this is your first run — proceed without prior context.
 
+Also call `engram_query` with topic `"inbox triage filing decisions"` scoped to `"sorter/findings"` to load any cross-agent triage discoveries. Keep the Post-it read — Engram is additive.
+
 ### At the END of every execution
 
 **You MUST write your post-it. This is not optional.** Write (or overwrite if it already exists) `Meta/states/sorter.md` with:
@@ -326,5 +330,7 @@ last-run: "{{ISO timestamp}}"
 ```
 
 **What to save**: files still in inbox after triage, notes you were unsure about (with your reasoning), filing patterns you noticed, areas that seem to be growing fast.
+
+Also call `engram_commit` for any significant findings, using scope `"sorter/findings"`, `confidence: 0.9` for verified findings or `0.7` for inferences, and `fact_type: "observation"` for facts found or `"decision"` for choices made. Keep the Post-it write intact — Engram is additive.
 
 **Max 30 lines** in the Post-it body. If you need more, summarize. This is a post-it, not a journal.

--- a/agents/transcriber.md
+++ b/agents/transcriber.md
@@ -49,6 +49,8 @@ When you detect work that another agent should handle, include a `### Suggested 
 - **Connector** → when a meeting note references decisions or context from past meetings that should be wikilinked
 - **Sorter** → when you're unsure whether the meeting note belongs to a specific project folder vs. the general Meetings folder
 
+Before suggesting work for another agent, call engram_query scoped to that agent's domain to check what they already know — avoid duplicating work they've recorded.
+
 ### Output format for suggestions
 
 ```markdown
@@ -128,6 +130,8 @@ You have a personal post-it at `Meta/states/transcriber.md`. This is your memory
 
 Read `Meta/states/transcriber.md` if it exists. It contains notes you left for yourself last time — e.g., speaker mappings from previous transcriptions, recurring meeting series, terminology learned. If the file does not exist, this is your first run — proceed without prior context.
 
+Also call `engram_query` with topic `"transcription findings"` scoped to `"transcriber/findings"` to load any cross-agent transcription discoveries. Keep the Post-it read — Engram is additive.
+
 ### At the END of every execution
 
 **You MUST write your post-it. This is not optional.** Write (or overwrite if it already exists) `Meta/states/transcriber.md` with:
@@ -144,5 +148,7 @@ last-run: "{{ISO timestamp}}"
 ```
 
 **What to save**: speaker names/roles learned, meeting series context, domain terminology discovered, action items that were assigned, pending follow-ups from transcriptions.
+
+Also call `engram_commit` for any significant findings, using scope `"transcriber/findings"`, `confidence: 0.9` for verified findings or `0.7` for inferences, and `fact_type: "observation"` for facts found or `"decision"` for choices made. Keep the Post-it write intact — Engram is additive.
 
 **Max 30 lines** in the Post-it body. If you need more, summarize. This is a post-it, not a journal.

--- a/mcp/servers.yaml
+++ b/mcp/servers.yaml
@@ -9,3 +9,9 @@ servers:
     url: "https://gcal.mcp.claude.com/mcp"
     env: {}
     exclude: []
+  - name: engram
+    type: stdio
+    command: uvx
+    args: [engram-memory, serve, --mcp]
+    env: {}
+    exclude: []

--- a/skills/engram-briefing/SKILL.md
+++ b/skills/engram-briefing/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: engram-briefing
+description: >
+  Cross-agent status report from Engram shared memory. Queries all 8 agent scopes
+  and produces a single read-only briefing showing what every agent has discovered
+  and committed. No writes to vault or Engram.
+  Trigger: "/engram-briefing"
+---
+
+# Engram Briefing — Cross-Agent Status Report
+
+Always respond to the user in their language. Match the language the user writes in.
+
+Query Engram shared memory for all 8 agent scopes and produce a single cross-agent status report. This skill is read-only — no writes to the vault or to Engram.
+
+---
+
+## Procedure
+
+Call `engram_query` once per agent scope, in order:
+
+1. topic: `"vault structure decisions"` — scope: `"architect/findings"`
+2. topic: `"note capture patterns"` — scope: `"scribe/findings"`
+3. topic: `"inbox triage filing decisions"` — scope: `"sorter/findings"`
+4. topic: `"vault search gaps"` — scope: `"seeker/findings"`
+5. topic: `"link gaps orphan clusters"` — scope: `"connector/findings"`
+6. topic: `"vault health issues findings"` — scope: `"librarian/findings"`
+7. topic: `"transcription findings"` — scope: `"transcriber/findings"`
+8. topic: `"email calendar import findings"` — scope: `"postman/findings"`
+
+For each scope, extract and display facts up to a limit of 10 per agent. Include each fact's confidence score and fact_type for transparency. After collecting all 8 scopes, scan for cross-agent conflicts (findings that contradict each other) and list them separately.
+
+---
+
+## Output Format
+
+```
+Engram Briefing — {{date}}
+
+## Architect — Vault Structure
+{{findings from architect/findings with confidence and fact_type, or "No recorded findings."}}
+
+## Scribe — Note Capture
+{{findings from scribe/findings with confidence and fact_type, or "No recorded findings."}}
+
+## Sorter — Inbox Triage
+{{findings from sorter/findings with confidence and fact_type, or "No recorded findings."}}
+
+## Seeker — Search & Retrieval
+{{findings from seeker/findings with confidence and fact_type, or "No recorded findings."}}
+
+## Connector — Knowledge Graph
+{{findings from connector/findings with confidence and fact_type, or "No recorded findings."}}
+
+## Librarian — Vault Health
+{{findings from librarian/findings with confidence and fact_type, or "No recorded findings."}}
+
+## Transcriber — Audio & Meetings
+{{findings from transcriber/findings with confidence and fact_type, or "No recorded findings."}}
+
+## Postman — Email & Calendar
+{{findings from postman/findings with confidence and fact_type, or "No recorded findings."}}
+
+---
+Cross-agent conflicts: {{list any findings that contradict each other across agent scopes, or "None detected."}}
+```
+
+---
+
+## Rules
+
+- This skill is **read-only**. Do not call `engram_commit`. Do not write or modify any vault files.
+- If `engram_query` returns no results for a scope, write "No recorded findings." for that agent.
+- List each finding with its confidence score and fact_type for transparency.
+- Highlight any cross-agent conflicts (e.g., Librarian flagged an area the Architect just created as missing).


### PR DESCRIPTION
Closes issue #3 
 
 Summary                                                   

  - Add Meta/crew-state.md — single-writer flat file storing the current wellness signal (high-stress, stable,     
  low-energy) with a timestamp; Wellness Guide owns writes, all other agents read-only
  - Wellness Guide writes signal to crew-state.md at session end                                                   
  - Postman reads signal before output; compresses triage and skips low-priority items under high-stress
  - Sorter reads signal; defers non-critical inbox items and shortens digest under high-stress                     
  - CLAUDE.md dispatcher skips unprompted agent chains under high-stress                                           
                                                                                                                   
  No new infrastructure — one flat file, trivially auditable and manually resettable.                              
                                                                                                                   
  Test plan                                                                                                        
   
  - Wellness Guide writes correct signal to crew-state.md                                                          
  - Postman and Sorter output is visibly compressed under high-stress
  - Dispatcher suppresses unprompted chains under high-stress
  - stable restores normal output across all agents                                                                
   
  If there are any issues pleas let me know, and I will re-implement the PR.       