### PR TITLE
fix(protect-system-files): anchor path matching to vault root

### DIFF
--- a/hooks/protect-system-files.sh
+++ b/hooks/protect-system-files.sh
@@ -11,6 +11,11 @@
 # determine which paths to protect. Falls back to .claude / CLAUDE.md if
 # the fields are missing (backward compatibility).
 #
+# Path matching is anchored to the actual vault root (resolved from this
+# script's location), so the hook only protects files inside the vault that
+# installed it — not arbitrary `.claude/` directories elsewhere on the system
+# (e.g. user-global ~/.claude/skills/, or other projects' .claude/ dirs).
+#
 # Exit codes:
 #   0 = allow the operation
 #   2 = block the operation (hard reject)
@@ -26,15 +31,30 @@ BASENAME=$(basename "$FILE")
 PLATFORM_DIR=$(echo "$INPUT" | jq -r '.platform_dir // ".claude"' 2>/dev/null)
 DISPATCHER_NAME=$(echo "$INPUT" | jq -r '.dispatcher_name // "CLAUDE.md"' 2>/dev/null)
 
+# Resolve the absolute path to the vault that this hook protects.
+# The hook lives at <vault>/<platform_dir>/hooks/protect-system-files.sh, so
+# the vault root is two parents up from this script's directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VAULT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PLATFORM_PATH="$VAULT_ROOT/$PLATFORM_DIR"
+DISPATCHER_PATH="$VAULT_ROOT/$DISPATCHER_NAME"
+
 # ── Dispatcher file: never modify at runtime ──────────────────────────────
-if [[ "$BASENAME" == "$DISPATCHER_NAME" && "$FILE" != *"$PLATFORM_DIR/"* ]]; then
+# Match the exact dispatcher path at the vault root. (A CLAUDE.md elsewhere
+# — in a sibling project, in the source repo — is not our concern.)
+if [[ "$FILE" == "$DISPATCHER_PATH" ]]; then
   echo "BLOCKED: $DISPATCHER_NAME is a system file. Update it in the repo and run updateme.sh."
   exit 2
 fi
 
+# Files outside this vault's platform directory are not our concern.
+if [[ "$FILE" != "$PLATFORM_PATH/"* ]]; then
+  exit 0
+fi
+
 # ── Core agent definitions: never modify at runtime ─────────────────────────
 CORE_AGENTS="architect.md scribe.md sorter.md seeker.md connector.md librarian.md transcriber.md postman.md"
-if [[ "$FILE" == *"$PLATFORM_DIR/agents/"* ]]; then
+if [[ "$FILE" == "$PLATFORM_PATH/agents/"* ]]; then
   for core in $CORE_AGENTS; do
     if [[ "$BASENAME" == "$core" ]]; then
       echo "BLOCKED: $BASENAME is a core agent definition. Update it in the repo and run updateme.sh."
@@ -46,13 +66,13 @@ if [[ "$FILE" == *"$PLATFORM_DIR/agents/"* ]]; then
 fi
 
 # ── Skills: never modify at runtime ─────────────────────────────────────────
-if [[ "$FILE" == *"$PLATFORM_DIR/skills/"* ]]; then
+if [[ "$FILE" == "$PLATFORM_PATH/skills/"* ]]; then
   echo "BLOCKED: Skill files are managed by the repo. Update them in the repo and run updateme.sh."
   exit 2
 fi
 
 # ── Core references: block all except user-mutable ones ─────────────────────
-if [[ "$FILE" == *"$PLATFORM_DIR/references/"* ]]; then
+if [[ "$FILE" == "$PLATFORM_PATH/references/"* ]]; then
   USER_MUTABLE="agents-registry.md agents.md"
   for allowed in $USER_MUTABLE; do
     [[ "$BASENAME" == "$allowed" ]] && exit 0


### PR DESCRIPTION
## Problem

The `protect-system-files` hook uses substring matches like `*"$PLATFORM_DIR/skills/"*` against file paths, where `PLATFORM_DIR` defaults to `.claude`. That pattern matches **any** path containing `.claude/skills/` — not just paths inside the vault that installed the hook.

Real-world impact: a Claude session running in a Brain vault was blocked from writing to `~/.claude/skills/candidate-eval/SKILL.md` (the user's personal global skills dir), even though that path has nothing to do with the Brain vault. Same overreach affected `paraform/.claude/skills/...` and any other project's `.claude/` directory.

The dispatcher check (`CLAUDE.md`) had a similar issue — a `CLAUDE.md` in a sibling project would be blocked because its path didn't contain `.claude/`.

## Fix

Resolve the absolute vault root from the hook's own location at runtime:

```bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
VAULT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
PLATFORM_PATH="$VAULT_ROOT/$PLATFORM_DIR"
DISPATCHER_PATH="$VAULT_ROOT/$DISPATCHER_NAME"
```

Then change every check from substring match (`*"$PLATFORM_DIR/skills/"*`) to absolute prefix match (`"$PLATFORM_PATH/skills/"*`). The hook now protects only files inside the vault that installed it.

Includes an early-exit: any file path that isn't under `$PLATFORM_PATH` is no longer this hook's concern, so we exit 0 immediately without running the agent/skills/references checks.

## Verification

Smoke-tested locally with the patched hook deployed to a real vault. All 11 cases pass:

**Should BLOCK (4)** — protection still works as intended:
- `Brain/.claude/skills/onboarding/SKILL.md` → exit 2 ✓
- `Brain/.claude/agents/architect.md` → exit 2 ✓
- `Brain/CLAUDE.md` (dispatcher) → exit 2 ✓
- `Brain/.claude/references/agent-orchestration.md` → exit 2 ✓

**Should ALLOW (4)** — these are the bug fixes:
- `~/.claude/skills/candidate-eval/SKILL.md` → exit 0 ✓ (was incorrectly blocked)
- `code/My-Brain-Is-Full-Crew/CLAUDE.md` → exit 0 ✓ (was incorrectly blocked)
- `paraform/.claude/skills/something/file.md` → exit 0 ✓ (was incorrectly blocked)
- `~/.claude/agents/some-custom.md` → exit 0 ✓ (was incorrectly blocked)

**Should ALLOW (3)** — regression check, already worked:
- `Brain/.claude/agents/my-custom-agent.md` (custom agent) → exit 0 ✓
- `Brain/.claude/references/agents-registry.md` (user-mutable) → exit 0 ✓
- `Brain/00-Inbox/random.md` (outside `.claude/`) → exit 0 ✓

## Backward compatibility

Behavior for in-vault writes is identical. The only behavior change is that paths outside the vault no longer falsely match. No changes to inputs (the JSON schema or the wrapper template), no changes to user-facing error messages.

## Notes

- The hook still trusts `platform_dir` from the JSON input (defaults to `.claude`). It just composes that with the vault root resolved from `BASH_SOURCE`, instead of relying on substring matching.
- A behavioral test for this hook would be a nice follow-up — happy to add one in a separate PR if you'd like.